### PR TITLE
Temporarily limit files per subdir, document in Manual

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -13,7 +13,7 @@ Under the `util` folder there is a command line tool named `lgptconvert.py` that
 
 ## Importing Samples
 
-picoTracker copies samples from the SD card into Flash memory for playing, this limits the amount of samples space to 1MB on pico based picoTracker or 16MB on a "portable model" picoTracker. It supports 8 or 16 Bit wav files, any sampling frequency, mono or stereo. 8bit samples are converted to 16bit at load time for compatibility with the engine (you can save space in storage but not in RAM, keep this in mind when choosing samples).
+picoTracker copies samples from the SD card into Flash memory for playing, this limits the amount of samples space to the available flash space *minus* the space taken by the firmware itself, which is currently approximately 1MB. It supports 8 or 16 Bit wav files, any sampling frequency, mono or stereo. 8bit samples are converted to 16bit at load time for compatibility with the engine (you can save space in storage but not in RAM, keep this in mind when choosing samples).
 
 Samples are saved into a `samples` subfolder in each individual project folder. Samples will be placed there when importing using the Instrument Sample Import dialog. They could be copied manually into the project directory in the SD from a computer, but be mindfull of the storage space used, all samples in the `samples` directory of the project will be loaded upon project loading, whether they are assigned to an instrument or not. The safest way is to place any samples into the `samplelib` directory and then load them into projects from the UI.
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -13,9 +13,11 @@ Under the `util` folder there is a command line tool named `lgptconvert.py` that
 
 ## Importing Samples
 
-picoTracker copies samples from the SD card into Flash memory for playing, this limits the amount of samples space to 1MB. It supports 8 or 16 Bit wav files, any sampling frequency, mono or stereo. 8bit samples are converted to 16bit at load time for compatibility with the engine (you can save space in storage but not in RAM, keep this in mind when choosing samples).
+picoTracker copies samples from the SD card into Flash memory for playing, this limits the amount of samples space to 1MB on pico based picoTracker or 16MB on a "portable model" picoTracker. It supports 8 or 16 Bit wav files, any sampling frequency, mono or stereo. 8bit samples are converted to 16bit at load time for compatibility with the engine (you can save space in storage but not in RAM, keep this in mind when choosing samples).
 
 Samples are saved into a `samples` subfolder in each individual project folder. Samples will be placed there when importing using the Instrument Sample Import dialog. They could be copied manually into the project directory in the SD from a computer, but be mindfull of the storage space used, all samples in the `samples` directory of the project will be loaded upon project loading, whether they are assigned to an instrument or not. The safest way is to place any samples into the `samplelib` directory and then load them into projects from the UI.
+
+__NOTE:__ Please be aware that due to a temporary issue with the current picoTracker firmware and limited RAM available, there is a **limit** of 25 sample files per subdirectory inside `samplelib`. Filenames are also temporarily limited to a maximum of 32 ASCII characters.
 
 ### samplelib
 The `samplelib` folder at the root of the SD card is where picoTracker will look samples to import into projects. You can place as many samples as you'd like here and in any directory hierarchy. Samples can be previewed before importing into projects.

--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
@@ -23,7 +23,12 @@ void picoTrackerDir::GetContent(const char *mask) {
   int count = 0;
 
   FsBaseFile entry;
-  while (entry.openNext(&dir, O_READ) && count <= PICO_MAX_FILE_COUNT) {    
+  while (entry.openNext(&dir, O_READ)) {
+    if (count == (PICO_MAX_FILE_COUNT + 1)) {
+      Path *fakePath = new Path("___.wav");
+      Insert(fakePath);
+      break;
+    }    
     char current[PICO_MAX_FILENAME_LEN];
     entry.getName(current, PICO_MAX_FILENAME_LEN);
     char *c = current;

--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
@@ -20,10 +20,12 @@ void picoTrackerDir::GetContent(const char *mask) {
     return;
   }
 
+  int count = 0;
+
   FsBaseFile entry;
-  while (entry.openNext(&dir, O_READ)) {
-    char current[128];
-    entry.getName(current, 128);
+  while (entry.openNext(&dir, O_READ) && count <= PICO_MAX_FILE_COUNT) {    
+    char current[PICO_MAX_FILENAME_LEN];
+    entry.getName(current, PICO_MAX_FILENAME_LEN);
     char *c = current;
     while (*c) {
       *c = tolower(*c);
@@ -31,7 +33,7 @@ void picoTrackerDir::GetContent(const char *mask) {
     }
 
     if (wildcardfit(mask, current)) {
-      entry.getName(current, 128);
+      entry.getName(current, PICO_MAX_FILENAME_LEN);
       std::string fullpath = path_;
       if (path_[strlen(path_) - 1] != '/') {
         fullpath += "/";
@@ -40,6 +42,7 @@ void picoTrackerDir::GetContent(const char *mask) {
       Path *path = new Path(fullpath.c_str());
       Insert(path);
     }
+    count++;
   }
   // Insert a parent dir path given that FatFS doesn't provide it
   Path cur(this->path_);

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
@@ -76,6 +76,10 @@ void ImportSampleDialog::DrawView() {
 			}
 			if (!current.IsDirectory()) {
 				strcpy(buffer,p.c_str()) ;
+                // temporary UI to show temporary dir file count limit reached
+                if (count == PICO_MAX_FILE_COUNT) {
+                    strcpy(buffer, "[*MAX FILES LIMIT*]");
+                }
 			} else {
 				buffer[0]='[' ;
 				strcpy(buffer+1,p.c_str()) ;

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
@@ -75,16 +75,18 @@ void ImportSampleDialog::DrawView() {
 				props.invert_=false ;
 			}
 			if (!current.IsDirectory()) {
-				strcpy(buffer,p.c_str()) ;
-                // temporary UI to show temporary dir file count limit reached
-                if (count == PICO_MAX_FILE_COUNT) {
-                    strcpy(buffer, "[*MAX FILES LIMIT*]");
-                }
+				strcpy(buffer,p.c_str()) ;                
 			} else {
 				buffer[0]='[' ;
 				strcpy(buffer+1,p.c_str()) ;
 				strcat(buffer,"]") ;
 			}
+		#ifdef PICO_BUILD 
+			// temporary UI to show temporary dir file count limit reached
+            if (count == (PICO_MAX_FILE_COUNT + 1)) {
+                strcpy(buffer, "[*MAX FILES LIMIT*]");
+            }
+		#endif
 			buffer[LIST_WIDTH-1]=0 ;
 			DrawString(x,y,buffer,props) ;
 			y+=1 ;

--- a/sources/System/FileSystem/FileSystem.h
+++ b/sources/System/FileSystem/FileSystem.h
@@ -12,6 +12,10 @@
 
 #define MAX_FILENAME_SIZE 256
 
+// temporary limits due to limited ram on RP2040  
+#define PICO_MAX_FILENAME_LEN 32
+#define PICO_MAX_FILE_COUNT 25
+
 enum FileType {
 	FT_UNKNOWN,
 	FT_FILE,


### PR DESCRIPTION
For now limit the number of files per sub directory in `samplelib` to 25 per sub directory and truncate filenames to 32 characters.

Basic UI is also added to indicate when the limit is reached.

@democloid I think there may also be a memory leak with `ImportSampleDialog` but I need to spend a bit more time debugging it and can do a followup PR if I find that it is the case.