### PR TITLE
Remove temp file limit

### DIFF
--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
@@ -23,14 +23,9 @@ void picoTrackerDir::GetContent(const char *mask) {
   int count = 0;
 
   FsBaseFile entry;
-  while (entry.openNext(&dir, O_READ)) {
-    if (count == (PICO_MAX_FILE_COUNT + 1)) {
-      Path *fakePath = new Path("___.wav");
-      Insert(fakePath);
-      break;
-    }    
-    char current[PICO_MAX_FILENAME_LEN];
-    entry.getName(current, PICO_MAX_FILENAME_LEN);
+  while (entry.openNext(&dir, O_READ)) {    
+    char current[MAX_FILENAME_SIZE];
+    entry.getName(current, MAX_FILENAME_SIZE);
     char *c = current;
     while (*c) {
       *c = tolower(*c);
@@ -38,7 +33,7 @@ void picoTrackerDir::GetContent(const char *mask) {
     }
 
     if (wildcardfit(mask, current)) {
-      entry.getName(current, PICO_MAX_FILENAME_LEN);
+      entry.getName(current, MAX_FILENAME_SIZE);
       std::string fullpath = path_;
       if (path_[strlen(path_) - 1] != '/') {
         fullpath += "/";

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
@@ -41,12 +41,16 @@ void ImportSampleDialog::DrawView() {
 
 // Draw title
 
-//	char title[40] ;
+#ifdef SHOW_MEM_USAGE
+	char title[40] ;
 
 	SetColor(CD_NORMAL) ;
 
-//	sprintf(title,"Sample Import from %s",currentPath_.GetName()) ;
-//	w_.DrawString(title,pos,props) ;
+	sprintf(title,"MEM [%d]", System::GetInstance()->GetMemoryUsage()) ;
+	GUIPoint pos = GUIPoint(0, 0);
+	w_.DrawString(title, pos, props);
+
+#endif
 
 // Draw samples
 

--- a/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/ImportSampleDialog.cpp
@@ -86,12 +86,6 @@ void ImportSampleDialog::DrawView() {
 				strcpy(buffer+1,p.c_str()) ;
 				strcat(buffer,"]") ;
 			}
-		#ifdef PICO_BUILD 
-			// temporary UI to show temporary dir file count limit reached
-            if (count == (PICO_MAX_FILE_COUNT + 1)) {
-                strcpy(buffer, "[*MAX FILES LIMIT*]");
-            }
-		#endif
 			buffer[LIST_WIDTH-1]=0 ;
 			DrawString(x,y,buffer,props) ;
 			y+=1 ;

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -17,9 +17,10 @@ set(PICO_EXAMPLES_PATH ${PROJECT_SOURCE_DIR})
 add_definitions(-DPICOBUILD)
 
 # For debugging purposes, print all mallocs
-#add_definitions(-DPICO_DEBUG_MALLOC)
+# add_definitions(-DPICO_DEBUG_MALLOC)
 # add_definitions(-DPICOSTATS)
-#add_definitions(-DALL_MALLOC)
+# add_definitions(-DALL_MALLOC)
+add_definitions(-DSHOW_MEM_USAGE)
 add_definitions(-DDISABLESF)
 # Enable SDIO - this setting affects code in SdFat library as well as the project
 # This consumes ~7k+ RAM and has some performance problems ATM
@@ -31,7 +32,7 @@ add_definitions(-DDISABLESF)
 # Enable loading samples into Flash
 add_definitions(-DLOAD_IN_FLASH)
 # Disable MIDI. Enable in order to use UART0 as stdio for debugging
-# add_definitions(-DDUMMY_MIDI)
+add_definitions(-DDUMMY_MIDI)
 # Disable feedback for sample instruments. Due to low memory in the PICO
 # there is very low chance to bring this back
 add_definitions(-DDISABLE_FEEDBACK)
@@ -76,7 +77,7 @@ target_compile_definitions(picoTracker PUBLIC
 #endif()
 
 # Debug output with USB uses +6K memory
-pico_enable_stdio_usb(${PROJECT_NAME} 0)
+pico_enable_stdio_usb(${PROJECT_NAME} 1)
 pico_enable_stdio_uart(${PROJECT_NAME} 0)
 
 # This is the default, but better to make it explicit

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -17,10 +17,9 @@ set(PICO_EXAMPLES_PATH ${PROJECT_SOURCE_DIR})
 add_definitions(-DPICOBUILD)
 
 # For debugging purposes, print all mallocs
-# add_definitions(-DPICO_DEBUG_MALLOC)
+#add_definitions(-DPICO_DEBUG_MALLOC)
 # add_definitions(-DPICOSTATS)
-# add_definitions(-DALL_MALLOC)
-add_definitions(-DSHOW_MEM_USAGE)
+#add_definitions(-DALL_MALLOC)
 add_definitions(-DDISABLESF)
 # Enable SDIO - this setting affects code in SdFat library as well as the project
 # This consumes ~7k+ RAM and has some performance problems ATM
@@ -32,7 +31,7 @@ add_definitions(-DDISABLESF)
 # Enable loading samples into Flash
 add_definitions(-DLOAD_IN_FLASH)
 # Disable MIDI. Enable in order to use UART0 as stdio for debugging
-add_definitions(-DDUMMY_MIDI)
+# add_definitions(-DDUMMY_MIDI)
 # Disable feedback for sample instruments. Due to low memory in the PICO
 # there is very low chance to bring this back
 add_definitions(-DDISABLE_FEEDBACK)
@@ -77,7 +76,7 @@ target_compile_definitions(picoTracker PUBLIC
 #endif()
 
 # Debug output with USB uses +6K memory
-pico_enable_stdio_usb(${PROJECT_NAME} 1)
+pico_enable_stdio_usb(${PROJECT_NAME} 0)
 pico_enable_stdio_uart(${PROJECT_NAME} 0)
 
 # This is the default, but better to make it explicit

--- a/sources/System/FileSystem/FileSystem.h
+++ b/sources/System/FileSystem/FileSystem.h
@@ -12,10 +12,6 @@
 
 #define MAX_FILENAME_SIZE 256
 
-// temporary limits due to limited ram on RP2040  
-#define PICO_MAX_FILENAME_LEN 32
-#define PICO_MAX_FILE_COUNT 25
-
 enum FileType {
 	FT_UNKNOWN,
 	FT_FILE,


### PR DESCRIPTION
@democloid while working on reducing ram usage of the filesystem I noticed a couple of bugs in my previous changes to temporarily set a limit on the number of files per directory, so this removes that change to fix the bugs while I continue to work on the ram usage improvements which are a much bigger change.