### PR TITLE
add KEYMAPSTYLE to valid picotrackers configs

### DIFF
--- a/sources/Application/Model/Config.cpp
+++ b/sources/Application/Model/Config.cpp
@@ -25,7 +25,9 @@ Config::Config()
     if (strcmp(doc.ElemName(), "BACKGROUND") &&
         strcmp(doc.ElemName(), "FOREGROUND") &&
         strcmp(doc.ElemName(), "HICOLOR1") &&
-        strcmp(doc.ElemName(), "HICOLOR2")) {
+        strcmp(doc.ElemName(), "HICOLOR2") &&
+        strcmp(doc.ElemName(), "KEYMAPSTYLE") 
+      ) {
       Trace::Log("CONFIG", "Found unknown config parameter \"%s\", skipping...", doc.ElemName());
       validElem = false;
     }


### PR DESCRIPTION
This fixes previous PR #16 to actually apply the setting as the need to add the config name to list in `Config.h` was missed 🤦🏻‍♂️  