### PR TITLE
Paged file browser

### DIFF
--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.h
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.h
@@ -5,6 +5,7 @@
 #include "System/FileSystem/FileSystem.h"
 #include <stdio.h>
 #include <string.h>
+#include <vector>
 
 class picoTrackerFile : public I_File {
 public:
@@ -29,11 +30,29 @@ public:
   virtual void GetContent(const char *mask);
 };
 
+class picoTrackerPagedDir : public I_PagedDir {
+public:
+  picoTrackerPagedDir(const char *path);
+  virtual ~picoTrackerPagedDir() {
+    Trace::Log("PAGEDDIR", "Destruct:%s", path_.c_str());
+  };
+  void GetContent(const char *mask);
+  std::string getFullName(int index);
+  void getFileList(int startIndex, std::vector<FileListItem> *fileList);
+  int size();
+
+private:
+  const std::string path_;
+  std::vector<int> fileIndexes_{};
+  std::vector<int> subdirIndexes_{};
+};
+
 class picoTrackerFileSystem : public FileSystem {
 public:
   picoTrackerFileSystem();
   virtual I_File *Open(const char *path, const char *mode);
   virtual I_Dir *Open(const char *path);
+  virtual I_PagedDir *OpenPaged(const char *path);
   virtual FileType GetFileType(const char *path);
   virtual Result MakeDir(const char *path);
   virtual void Delete(const char *){};
@@ -41,4 +60,5 @@ public:
 private:
   SdFs SD_;
 };
+
 #endif

--- a/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
@@ -52,6 +52,7 @@ picoTrackerGUIWindowImp::picoTrackerGUIWindowImp(GUICreateWindowParams &p) {
   const char *keymapStyle = config->GetValue("KEYMAPSTYLE");
   if (strcasecmp("M8",keymapStyle) == 0) {
     eventMapping = eventMappingM8;
+    Trace::Log("GUIWINDOWIMP", "Using M8 keymap");
   }
 };
 

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -8,6 +8,7 @@
 #include "BaseClasses/UINoteVarField.h"
 #include "BaseClasses/UIStaticField.h"
 #include "ModalDialogs/ImportSampleDialog.h"
+#include "ModalDialogs/PagedImportSampleDialog.h"
 #include "ModalDialogs/MessageBox.h"
 #include "System/System/System.h"
 
@@ -48,11 +49,11 @@ void InstrumentView::onInstrumentChange() {
 
   switch (it) {
   case IT_MIDI:
-    fillMidiParameters() ;
-    break ;
+    fillMidiParameters();
+    break;
   case IT_SAMPLE:
-    fillSampleParameters() ;
-    break ;
+    fillSampleParameters();
+    break;
   };
 
   SetFocus(T_SimpleList<UIField>::GetFirst());
@@ -199,8 +200,9 @@ void InstrumentView::fillSampleParameters() {
 
   position._y += 1;
   v = instrument->FindVariable(SIP_TABLE);
-  f1 = new UIIntVarOffField(position, *v, "table: %2.2X", 0x00, TABLE_COUNT - 1, 1, 0x10);
-  T_SimpleList<UIField>::Insert(f1) ;
+  f1 = new UIIntVarOffField(position, *v, "table: %2.2X", 0x00, TABLE_COUNT - 1,
+                            1, 0x10);
+  T_SimpleList<UIField>::Insert(f1);
 };
 
 void InstrumentView::fillMidiParameters() {
@@ -278,7 +280,8 @@ void InstrumentView::ProcessButtonMask(unsigned short mask, bool pressed) {
           } else {
             ;
             // Go to import sample
-            ImportSampleDialog *isd = new ImportSampleDialog(*this);
+            // ImportSampleDialog *isd = new ImportSampleDialog(*this);
+            PagedImportSampleDialog *isd = new PagedImportSampleDialog(*this);
             DoModal(isd);
           }
         } else {

--- a/sources/Application/Views/ModalDialogs/CMakeLists.txt
+++ b/sources/Application/Views/ModalDialogs/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(application_views_modaldialogs
   ImportSampleDialog.h ImportSampleDialog.cpp
+  PagedImportSampleDialog.h PagedImportSampleDialog.cpp
   MessageBox.h MessageBox.cpp
   NewProjectDialog.h NewProjectDialog.cpp
   SelectProjectDialog.h SelectProjectDialog.cpp

--- a/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
@@ -1,0 +1,267 @@
+#include "PagedImportSampleDialog.h"
+#include "Application/Instruments/SampleInstrument.h"
+#include "Application/Instruments/SamplePool.h"
+#include "pico/multicore.h"
+#include <memory>
+
+#define LIST_SIZE 15
+#define LIST_WIDTH 24
+
+static const char *buttonText[3] = {"Listen", "Import", "Exit"};
+
+PagedImportSampleDialog::PagedImportSampleDialog(View &view) : ModalView(view) {
+  selected_ = 0;
+  fileList_.reserve(15);
+  Trace::Log("PAGEDIMPORT", "samplelib is:%s", SAMPLE_LIB_PATH);
+}
+
+PagedImportSampleDialog::~PagedImportSampleDialog() {
+  Trace::Log("PAGEDIMPORT", "Destruct ===");
+}
+
+void PagedImportSampleDialog::DrawView() {
+  Trace::Log("PAGEDIMPORT", "DrawView current:%d topIdx:%d", currentSample_,
+             topIndex_);
+
+  SetWindow(LIST_WIDTH, LIST_SIZE + 3);
+  GUITextProperties props;
+
+// Draw title
+#ifdef SHOW_MEM_USAGE
+  char title[40];
+
+  SetColor(CD_NORMAL);
+
+  sprintf(title, "MEM [%d]", System::GetInstance()->GetMemoryUsage());
+  GUIPoint pos = GUIPoint(0, 0);
+  w_.DrawString(title, pos, props);
+
+#endif
+  // Draw samples
+  int x = 1;
+  int y = 1;
+
+  int count = 0;
+  char buffer[LIST_WIDTH + 1];
+  for (const FileListItem &current : fileList_) {
+    if (count == (currentSample_ % LIST_SIZE)) {
+      SetColor(CD_HILITE2);
+      props.invert_ = true;
+    } else {
+      SetColor(CD_NORMAL);
+      props.invert_ = false;
+    }
+    if (!current.isDirectory) {
+      strncpy(buffer, current.name.c_str(), LIST_WIDTH);
+    } else {
+      buffer[0] = '[';
+      strncpy(buffer + 1, current.name.c_str(), LIST_WIDTH - 2);
+      strcat(buffer, "]");
+    }
+    buffer[LIST_WIDTH] =
+        0; // make sure if truncated the filename we have trailing null
+    DrawString(x, y, buffer, props);
+    y += 1;
+    count++;
+  };
+
+  y = LIST_SIZE + 2;
+  int offset = 7;
+
+  SetColor(CD_NORMAL);
+
+  // Draw buttons
+  for (int i = 0; i < 3; i++) {
+    const char *text = buttonText[i];
+    x = (offset * (i + 1) - strlen(text) / 2) - 2;
+    props.invert_ = (i == selected_) ? true : false;
+    DrawString(x, y, text, props);
+  }
+};
+
+void PagedImportSampleDialog::warpToNextSample(int direction) {
+  currentSample_ += direction;
+  int size = currentDir_->size();
+  bool needPage = false;
+
+  // wrap around from first entry to last entry
+  if (currentSample_ < 0) {
+    topIndex_ = (size / LIST_SIZE) * LIST_SIZE;
+    currentSample_ = size - 1; // goto last entry
+    needPage = true;
+  }
+  // wrap around from last entry to first entry
+  if (currentSample_ >= size) {
+    currentSample_ = 0;
+    topIndex_ = 0;
+    needPage = true;
+  }
+
+  // if we have scrolled off the bottom, page the file list down if not at end
+  // of the list
+  if ((currentSample_ >= (topIndex_ + LIST_SIZE)) &&
+      ((topIndex_ + LIST_SIZE) < size)) {
+    topIndex_ += LIST_SIZE;
+    needPage = true;
+  }
+
+  // if we have scrolled off the top, page the file list up if not already at
+  // very top of the list
+  if (currentSample_ < topIndex_ && topIndex_ != 0) {
+    topIndex_ -= LIST_SIZE;
+    needPage = true;
+  }
+
+  // need to fetch a new page of the file list of current directory
+  if (needPage) {
+    fileList_.clear();
+    currentDir_->getFileList(topIndex_, &fileList_);
+  }
+
+  isDirty_ = true;
+}
+
+void PagedImportSampleDialog::OnPlayerUpdate(PlayerEventType,
+                                             unsigned int currentTick){};
+
+void PagedImportSampleDialog::OnFocus() {
+  Path current(currentPath_);
+  setCurrentFolder(&current);
+  toInstr_ = viewData_->currentInstrument_;
+};
+
+void PagedImportSampleDialog::preview(Path &element) {
+  Player::GetInstance()->StartStreaming(element);
+}
+
+void PagedImportSampleDialog::import(Path &element) {
+
+  SamplePool *pool = SamplePool::GetInstance();
+
+#ifdef PICO_BUILD
+  // Pause core1 in order to be able to write to flash and ensure core1 is
+  // not reading from it, it also disables IRQs on it
+  // https://www.raspberrypi.com/documentation/pico-sdk/high_level.html#multicore_lockout
+  multicore_lockout_start_blocking();
+#endif
+  int sampleID = pool->ImportSample(element);
+#ifdef PICO_BUILD
+  multicore_lockout_end_blocking();
+#endif
+
+  if (sampleID >= 0) {
+    I_Instrument *instr =
+        viewData_->project_->GetInstrumentBank()->GetInstrument(toInstr_);
+    if (instr->GetType() == IT_SAMPLE) {
+      SampleInstrument *sinstr = (SampleInstrument *)instr;
+      sinstr->AssignSample(sampleID);
+      toInstr_ = viewData_->project_->GetInstrumentBank()->GetNext();
+    };
+  } else {
+    Trace::Error("failed to import sample");
+  };
+  isDirty_ = true;
+};
+
+void PagedImportSampleDialog::ProcessButtonMask(unsigned short mask,
+                                                bool pressed) {
+
+  if (!pressed)
+    return;
+
+  if (mask & EPBM_B) {
+    if (mask & EPBM_UP)
+      warpToNextSample(-LIST_SIZE);
+    if (mask & EPBM_DOWN)
+      warpToNextSample(LIST_SIZE);
+  } else {
+    // A modifier
+    if (mask & EPBM_A) {
+      // make sure to index into the fileList with the offset from topIndex!
+      FileListItem currentItem = fileList_[currentSample_ - topIndex_];
+
+      if ((selected_ != 2) && currentItem.isDirectory) {
+        if (currentItem.name == std::string("..")) {
+          if (currentPath_.GetPath() == std::string(SAMPLE_LIB_PATH)) {
+            Trace::Log("PAGEDIMPORT",
+                       "already at root of samplelib nothing to do");
+          } else {
+            Path parent = currentPath_.GetParent();
+            setCurrentFolder(&parent);
+          }
+        } else {
+          auto fullName = currentDir_->getFullName(currentItem.index);
+          Path childDirPath = currentPath_.Descend(fullName);
+          setCurrentFolder(&childDirPath);
+        }
+        isDirty_ = true;
+        return;
+      }
+      auto fullPathStr = std::string(currentPath_.GetPath());
+      fullPathStr += "/";
+      fullPathStr += currentItem.name;
+      auto fullPath = Path{fullPathStr};
+
+      switch (selected_) {
+      case 0: // preview
+        preview(fullPath);
+        break;
+      case 1: // import
+        import(fullPath);
+        break;
+      case 2: // Exit ;
+        // make sure we free mem from existing currentDir instance
+        if (currentDir_ != NULL) {
+          delete currentDir_;
+        }
+        EndModal(0);
+        break;
+      }
+    } else {
+      // R Modifier
+      if (mask & EPBM_R) {
+      } else {
+        // No modifier
+        if (mask == EPBM_UP)
+          warpToNextSample(-1);
+        if (mask == EPBM_DOWN)
+          warpToNextSample(1);
+        if (mask == EPBM_LEFT) {
+          selected_ -= 1;
+          if (selected_ < 0)
+            selected_ += 3;
+          isDirty_ = true;
+        }
+        if (mask == EPBM_RIGHT) {
+          selected_ = (selected_ + 1) % 3;
+          isDirty_ = true;
+        }
+      }
+    }
+  }
+}
+
+void PagedImportSampleDialog::setCurrentFolder(Path *path) {
+  Trace::Log("PAGEDIMPORT", "set Current Folder:%s", path->GetPath().c_str());
+  Path formerPath(currentPath_);
+  topIndex_ = 0;
+  currentSample_ = 0;
+  currentPath_ = Path(*path);
+  fileList_.clear();
+  if (path) {
+    // make sure we free mem from existing currentDir instance
+    if (currentDir_ != NULL) {
+      delete currentDir_;
+    }
+    currentDir_ = FileSystem::GetInstance()->OpenPaged(path->GetPath().c_str());
+    // TODO: show "Loading..." mesg in UI
+    Trace::Log("PAGEDIMPORT", "Loading...");
+    currentDir_->GetContent("*.wav");
+    // TODO: hide "Loading..." mesg in UI
+    Trace::Log("PAGEDIMPORT", "Finished Loading");
+  }
+
+  // load first page of file/subdirs
+  fileList_.clear();
+  currentDir_->getFileList(topIndex_, &fileList_);
+}

--- a/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.h
+++ b/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.h
@@ -1,0 +1,36 @@
+#ifndef _PAGED_IMPORT_SAMPLE_DIALOG_H_
+#define _PAGED_IMPORT_SAMPLE_DIALOG_H_
+
+#include "Application/Views/BaseClasses/ModalView.h"
+#include "Foundation/T_SimpleList.h"
+#include "System/FileSystem/FileSystem.h"
+#include <string>
+#include <vector>
+
+class PagedImportSampleDialog : public ModalView {
+public:
+  PagedImportSampleDialog(View &view);
+  virtual ~PagedImportSampleDialog();
+
+  virtual void DrawView();
+  virtual void OnPlayerUpdate(PlayerEventType, unsigned int currentTick);
+  virtual void OnFocus();
+  virtual void ProcessButtonMask(unsigned short mask, bool pressed);
+
+protected:
+  void setCurrentFolder(Path *path);
+  void warpToNextSample(int dir);
+  void import(Path &element);
+  void preview(Path &element);
+
+private:
+  std::vector<FileListItem> fileList_{};
+  int currentSample_;
+  int topIndex_ = 0;
+  int toInstr_;
+  int selected_;
+  Path currentPath_{SAMPLE_LIB_PATH};
+  I_PagedDir *currentDir_{};
+};
+
+#endif

--- a/sources/Application/Views/ModalDialogs/SelectProjectDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/SelectProjectDialog.cpp
@@ -12,10 +12,7 @@
 #ifndef NO_EXIT
 static const char *buttonText[3] = {"Load", "New", "Exit"};
 #else
-static const char *buttonText[2]= {
-	"Load",
-	"New"
-} ;
+static const char *buttonText[2] = {"Load", "New"};
 #endif
 
 Path SelectProjectDialog::lastFolder_("root:");
@@ -199,7 +196,7 @@ void SelectProjectDialog::ProcessButtonMask(unsigned short mask, bool pressed) {
       }
     } else {
       // R Modifier
-      if (mask&EPBM_R) {
+      if (mask & EPBM_R) {
       } else {
         // No modifier
         if (mask == EPBM_UP)
@@ -209,9 +206,11 @@ void SelectProjectDialog::ProcessButtonMask(unsigned short mask, bool pressed) {
         if (mask == EPBM_LEFT) {
           selected_--;
 #ifdef NO_EXIT
-          if (selected_ < 0) selected_ += 2;
+          if (selected_ < 0)
+            selected_ += 2;
 #else
-          if (selected_ < 0) selected_ += 3;
+          if (selected_ < 0)
+            selected_ += 3;
 #endif
           isDirty_ = true;
         }
@@ -250,7 +249,6 @@ void SelectProjectDialog::warpToNextProject(int amount) {
 Path SelectProjectDialog::GetSelection() { return selection_; }
 
 Result SelectProjectDialog::OnNewProject(std::string &name) {
-
   Path path = currentPath_.Descend(name);
   Trace::Log("TMP", "creating project at %s", path.GetPath().c_str());
   selection_ = path;
@@ -279,16 +277,12 @@ void SelectProjectDialog::setCurrentFolder(Path &path) {
   I_Dir *dir = FileSystem::GetInstance()->Open(currentPath_.GetPath().c_str());
 
   if (dir) {
-
     // Get all lgpt something
-
     dir->GetContent("*");
     dir->Sort();
-
     IteratorPtr<Path> it(dir->GetIterator());
     for (it->Begin(); !it->IsDone(); it->Next()) {
       Path &path = it->CurrentItem();
-
       if (path.IsDirectory()) {
         std::string name = path.GetName();
         if (name[0] != '.' || name[1] == '.') {
@@ -299,7 +293,6 @@ void SelectProjectDialog::setCurrentFolder(Path &path) {
     }
     delete (dir);
   }
-
   // reset & redraw screen
   topIndex_ = 0;
   currentProject_ = 0;

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -17,9 +17,10 @@ set(PICO_EXAMPLES_PATH ${PROJECT_SOURCE_DIR})
 add_definitions(-DPICOBUILD)
 
 # For debugging purposes, print all mallocs
-#add_definitions(-DPICO_DEBUG_MALLOC)
+# add_definitions(-DPICO_DEBUG_MALLOC)
 # add_definitions(-DPICOSTATS)
-#add_definitions(-DALL_MALLOC)
+# add_definitions(-DALL_MALLOC)
+# add_definitions(-DSHOW_MEM_USAGE)
 add_definitions(-DDISABLESF)
 # Enable SDIO - this setting affects code in SdFat library as well as the project
 # This consumes ~7k+ RAM and has some performance problems ATM

--- a/sources/System/FileSystem/FileSystem.cpp
+++ b/sources/System/FileSystem/FileSystem.cpp
@@ -163,3 +163,8 @@ const char *Path::Alias::GetPath() { return path_.c_str(); }
 void Path::Alias::SetAliasName(const char *alias) { alias_ = alias; };
 
 void Path::Alias::SetPath(const char *path) { path_ = path; };
+
+I_PagedDir::I_PagedDir(){};
+I_PagedDir::~I_PagedDir(){};
+
+I_PagedDir::I_PagedDir(const char *path){};


### PR DESCRIPTION
This signficantly reduces the ram usage when using the import dialog to browse and import samples from the sdcard.

It changes the Import Dialog when built for picotracker to use a new `picoTrackerPagedDir` class that implements a new interface instead of `I_Dir`.  This changes the file system operations to be done in "pages" of files and only stores the indexes of file and subdirectory entries of the currently open directory and only fetches the names of entries on demand in "pages" limited in size to what the dialog UI can display at one time (currently 15).

The `ImportSampleDialog` is also heavily rewritten to make use of the interface and use as little ram as possible.

This doesn't impose any hard limits on the number of files per directory, but it does set initial sizes of max of `96` subdirs and `354` files per subdir so its quite possible that exceeding these limits could cause extra memory allocation to overflow available ram at the moment.

Please note this is "stacked" on top of PR #26 so that PR should be merged before this one is.

Note: these changes do mean that apart from having subdirs listed before files, there is no other sorting of entries in a directory being applied for now.

Also I've kept all my commits in this PR but I would recommend doing a "squash merge" as all these commits don't really need to be included in the main branches history.

Fixes #14 