### PR TITLE
Improve import preview playback ux

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -298,16 +298,25 @@ TODO: screencap
 
 ## Sample Import Screen
 
-Accessible by hitting A,A on the “sample” parameter in the Instrument Screen.
-The samples of the library have to be located in a folder samplelib at the same level as the song folders (lgpt-xxxx). you can either put your samples in that directory or in sub-directories, allowing you to have some basic way of sorting the library. For example:
+Accessible by hitting A,A on the “sample:” parameter in the Instrument Screen.
+
+The samples of the library **must** to be located in a folder named `samplelib` at the top-level of the sdcard (lgpt-xxxx). You can either put your samples in that directory or in sub-directories of it, allowing you to have a basic way of sorting the library. 
+
+Note: subdirectories will be sorted before files, but otherwise the files will be listed in an undetermined order (ie. not necessarily alphabetical order).
+
+For example:
 
 TODO: screencap
 
 When entering the import screen, the current folder is the library root folder “samplelib”. All sample in that folder are listed.
-Use Up/Down to select a sample and 'A' to load it
-B+Left/Right to rotates between all sub directories.
+
+Use Up/Down to select a sample and the Play button to start/stop preview playback of the sample.
+RT+Play to import the currently selected sample and RT+Left to exit out of the Import Dialog back to the Instrument Screen.
+
+Note: While there is no fixed limit for the number of files per subdirectory, exceding 96 subdirectories and/or 354 files per directory is likely to cause picotracker to potentially crash. Also please note that while FAT formatted sdcards can support upto 256 characters per filename, Picotracker only supports upto 128 and with only ASCII characters.
 
 ## Midi Instrument Screen
+
 TODO: screencap
 
 A midi instrument has the following settings:

--- a/sources/Application/Audio/AudioFileStreamer.cpp
+++ b/sources/Application/Audio/AudioFileStreamer.cpp
@@ -28,6 +28,8 @@ void AudioFileStreamer::Stop() {
   Trace::Debug("Streaming stopped");
 };
 
+bool AudioFileStreamer::IsPlaying() { return mode_ == AFSM_PLAYING; }
+
 bool AudioFileStreamer::Render(fixed *buffer, int samplecount) {
 
   // See if we're playing

--- a/sources/Application/Audio/AudioFileStreamer.h
+++ b/sources/Application/Audio/AudioFileStreamer.h
@@ -14,6 +14,7 @@ public:
   virtual bool Render(fixed *buffer, int samplecount);
   bool Start(const Path &);
   void Stop();
+  bool IsPlaying();
 
 protected:
   AudioFileStreamerMode mode_;

--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -1139,7 +1139,10 @@ PlayerEventType PlayerEvent::GetType() { return type_; };
 unsigned int PlayerEvent::GetTickCount() { return tickCount_; };
 
 void Player::StartStreaming(const Path &path) { mixer_->StartStreaming(path); }
+
 void Player::StopStreaming() { mixer_->StopStreaming(); }
+
+bool Player::IsPlaying() { return mixer_->IsPlaying(); }
 
 std::string Player::GetAudioAPI() {
   AudioOut *out = mixer_->GetAudioOut();

--- a/sources/Application/Player/Player.h
+++ b/sources/Application/Player/Player.h
@@ -62,6 +62,7 @@ public:
                      unsigned char chainPos);
   void OnSongStartButton(unsigned int from, unsigned int to, bool requestStop,
                          bool forceImmediate);
+  bool IsPlaying();
 
   bool IsRunning();
   bool Clipped();

--- a/sources/Application/Player/PlayerMixer.cpp
+++ b/sources/Application/Player/PlayerMixer.cpp
@@ -147,6 +147,10 @@ void PlayerMixer::StartStreaming(const Path &path) {
 
 void PlayerMixer::StopStreaming() { fileStreamer_.Stop(); };
 
+bool PlayerMixer::IsPlaying() {
+	return fileStreamer_.IsPlaying();
+}
+
 void PlayerMixer::OnPlayerStart() {
   MixerService *ms = MixerService::GetInstance();
   ms->OnPlayerStart();

--- a/sources/Application/Player/PlayerMixer.h
+++ b/sources/Application/Player/PlayerMixer.h
@@ -22,6 +22,7 @@ public:
 
   bool Start();
   void Stop();
+  bool IsPlaying();
   bool Init(Project *project);
   void Close();
 

--- a/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
@@ -131,7 +131,13 @@ void PagedImportSampleDialog::OnFocus() {
 };
 
 void PagedImportSampleDialog::preview(Path &element) {
-  Player::GetInstance()->StartStreaming(element);
+  if (Player::GetInstance()->IsPlaying()) {
+    printf("playing so stop");
+    Player::GetInstance()->StopStreaming();
+  } else {
+    printf("not playing so start");
+    Player::GetInstance()->StartStreaming(element);
+  }
 }
 
 void PagedImportSampleDialog::import(Path &element) {


### PR DESCRIPTION
This improves user ergonomics and replaces the existing onscreen buttons in the Sample Import Dialog with the their functionality being directly accessible via physical keys or key combos.

It also adds quality of life improvement by allowing preview playback to be stopped, which is especially useful for longer samples.

The manual has been updated to reflect these changes and also add some notes on the remaining filesystem restrictions of the new "paged" import dialog implementation.

Please note this is "stacked" onto PR #14 so that PR should be merged before this one and so unfortunately its a bit hard to see just the changes in this PR until that one is merged.

PS. this also saves 8 bytes of static ram alloc (in debug build, could be bit more in optimised build) :-)

Fixes: #31 , #32