### PR TITLE
Enable midi output

### DIFF
--- a/sources/Adapters/picoTracker/platform/platform.cpp
+++ b/sources/Adapters/picoTracker/platform/platform.cpp
@@ -152,6 +152,15 @@ void platform_init() {
    // Set up our UART with the required speed.
    baudrate = uart_init(MIDI_UART, MIDI_BAUD_RATE);
    printf("Init MIDI device with %i baud rate\n", baudrate);
+
+   // Set UART flow control CTS/RTS, we don't want these, so turn them off
+   uart_set_hw_flow(MIDI_UART, false, false);
+
+   // Set our data format
+   uart_set_format(MIDI_UART, 8, 1, UART_PARITY_NONE);
+
+   // Turn off FIFO's - we want to do this character by character
+   uart_set_fifo_enabled(MIDI_UART, false);
 #endif
 
    ///////////


### PR DESCRIPTION
Just these lines seem to be the missing code to get MIDI output working on the current master branch, taken from the `midiin` branch. 

It would be good to get this fixed asap and then get the MIDI in parts working later on.

Partially fixes #43 