### PR TITLE
Replace assertion error with log print

### DIFF
--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -855,7 +855,7 @@ void Player::playCursorPosition(int channel) {
             }
           }
         } else {
-          NAssert(0);
+          Trace::Error("Note outside range: %02x", (unsigned int)note);
         }
       }
     }


### PR DESCRIPTION
Transposing using phrase transposition might cause the application to crash Replace the assertion with a log print

from djdiskmachine/LittleGPTracker/pull/5