### PR TITLE
Workaround for some boards that need longer to init clock

### DIFF
--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -69,6 +69,8 @@ target_compile_definitions(picoTracker PUBLIC
   PICO_STACK_SIZE=4096
   PICO_CORE1_STACK_SIZE=4096 # Safe value. 2K seems to be enough. Is it for all use cases?
   PICO_USE_STACK_GUARDS
+  # workaround for slow init crystal on some boards see: https://github.com/raspberrypi/pico-sdk/pull/457
+  PICO_XOSC_STARTUP_DELAY_MULTIPLIER=8
 )
 
 #if (SD_SDIO)

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -70,7 +70,7 @@ target_compile_definitions(picoTracker PUBLIC
   PICO_CORE1_STACK_SIZE=4096 # Safe value. 2K seems to be enough. Is it for all use cases?
   PICO_USE_STACK_GUARDS
   # workaround for slow init crystal on some boards see: https://github.com/raspberrypi/pico-sdk/pull/457
-  PICO_XOSC_STARTUP_DELAY_MULTIPLIER=8
+  PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64
 )
 
 #if (SD_SDIO)


### PR DESCRIPTION
Some boards with the current PCB design seem to have an issue identified by other rp2040 users making custom PCBs with XOSC taking longer than expected to stabilise on boot.

This was verified as fixing the issue of the boards not booting after power cycle post flashing on 3 different boards, from 2 different manufacturing batches.

See this issue for more details: https://github.com/raspberrypi/pico-sdk/pull/457