### PR TITLE
Add note audition mode

### DIFF
--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -541,29 +541,27 @@ void Player::Update(Observable &o, I_ObservableData *d) {
     }
 
     // Do we need to kill a voice?
-    if (viewData_->playMode_ != PM_AUDITION) {
-      if (sync->TableSlice()) {
-        for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
-          bool stopped = false;
-          if (timeToLive_[i] > 0) {
-            if (--timeToLive_[i] == 0) {
-              mixer_->StopInstrument(i);
-              stopped = true;
-            }
+    if (sync->TableSlice()) {
+      for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
+        bool stopped = false;
+        if (timeToLive_[i] > 0) {
+          if (--timeToLive_[i] == 0) {
+            mixer_->StopInstrument(i);
+            stopped = true;
           }
-          if (!stopped) {
-            if (instrRetrigger[i] >= 0) {
-              int note = mixer_->GetChannelNote(i);
-              I_Instrument *instr = mixer_->GetInstrument(i);
-              if ((note != 0xFF) && (instr != 0)) {
-                note += (instrRetrigger[i] > 80) ? instrRetrigger[i] - 256
-                                                 : instrRetrigger[i];
-                while (note > 127) {
-                  note -= 12;
-                };
-                mixer_->StopInstrument(i);
-                mixer_->StartInstrument(i, instr, note, false);
+        }
+        if (!stopped) {
+          if (instrRetrigger[i] >= 0) {
+            int note = mixer_->GetChannelNote(i);
+            I_Instrument *instr = mixer_->GetInstrument(i);
+            if ((note != 0xFF) && (instr != 0)) {
+              note += (instrRetrigger[i] > 80) ? instrRetrigger[i] - 256
+                                               : instrRetrigger[i];
+              while (note > 127) {
+                note -= 12;
               };
+              mixer_->StopInstrument(i);
+              mixer_->StartInstrument(i, instr, note, false);
             };
           };
         }

--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -160,6 +160,16 @@ void Player::Start(PlayMode mode, bool forceSongMode) {
     updateSongPos(playPos, currentChannel, currentChainPos);
   } break;
 
+  case PM_AUDITION: {
+    int currentChannel = viewData_->songX_;
+    mixer_->StartChannel(currentChannel);
+
+    int currentChainPos = viewData_->chainRow_;
+    int currentPhrasePos = viewData_->phraseCurPos_;
+    // uses hop for PhrasePos
+    updateSongPos(playPos, currentChannel, currentChainPos, currentPhrasePos);
+  } break;
+
   default:
     NInvalid;
     break;
@@ -289,7 +299,7 @@ void Player::OnStartButton(PlayMode origin, unsigned int from,
 
     // If sequencer not running, start otherwise stop
 
-    if (isRunning_) {
+    if (isRunning_ && viewData_->playMode_ != PM_AUDITION) {
       Stop();
     } else {
       for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
@@ -313,7 +323,7 @@ void Player::OnSongStartButton(unsigned int from, unsigned int to,
 
     // If sequencer not running, start otherwise stop
 
-    if (isRunning_) {
+    if (isRunning_ && viewData_->playMode_ != PM_AUDITION) {
       if (!forceImmediate) {
         Stop();
       } else {
@@ -493,7 +503,9 @@ void Player::Update(Observable &o, I_ObservableData *d) {
         };
         retrigAllImmediate_ = false;
       }
-      moveToNextStep();
+      // Don't advance in audition mode
+      if (viewData_->playMode_ != PM_AUDITION)
+        moveToNextStep();
       if (triggerLiveChains_) {
         triggerLiveChains();
       };
@@ -508,15 +520,14 @@ void Player::Update(Observable &o, I_ObservableData *d) {
     }
 
     // Process commands in current phrase
-
-    ProcessCommands();
+    if (viewData_->playMode_ != PM_AUDITION)
+      ProcessCommands();
 
     // Initialise retrigger table
     int instrRetrigger[SONG_CHANNEL_COUNT];
     memset(instrRetrigger, -1, SONG_CHANNEL_COUNT * sizeof(int));
 
     // Process any table commands now
-
     for (int channel = 0; channel < SONG_CHANNEL_COUNT; channel++) {
       TablePlayback &tpb = TablePlayback::GetTablePlayback(channel);
       if (!tpb.GetAutomation()) {
@@ -529,32 +540,33 @@ void Player::Update(Observable &o, I_ObservableData *d) {
       }
     }
 
-    // Do we need to kill a voice ?
-
-    if (sync->TableSlice()) {
-      for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
-        bool stopped = false;
-        if (timeToLive_[i] > 0) {
-          if (--timeToLive_[i] == 0) {
-            mixer_->StopInstrument(i);
-            stopped = true;
-          }
-        }
-        if (!stopped) {
-          if (instrRetrigger[i] >= 0) {
-            int note = mixer_->GetChannelNote(i);
-            I_Instrument *instr = mixer_->GetInstrument(i);
-            if ((note != 0xFF) && (instr != 0)) {
-              note += (instrRetrigger[i] > 80) ? instrRetrigger[i] - 256
-                                               : instrRetrigger[i];
-              while (note > 127) {
-                note -= 12;
-              };
+    // Do we need to kill a voice?
+    if (viewData_->playMode_ != PM_AUDITION) {
+      if (sync->TableSlice()) {
+        for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
+          bool stopped = false;
+          if (timeToLive_[i] > 0) {
+            if (--timeToLive_[i] == 0) {
               mixer_->StopInstrument(i);
-              mixer_->StartInstrument(i, instr, note, false);
+              stopped = true;
+            }
+          }
+          if (!stopped) {
+            if (instrRetrigger[i] >= 0) {
+              int note = mixer_->GetChannelNote(i);
+              I_Instrument *instr = mixer_->GetInstrument(i);
+              if ((note != 0xFF) && (instr != 0)) {
+                note += (instrRetrigger[i] > 80) ? instrRetrigger[i] - 256
+                                                 : instrRetrigger[i];
+                while (note > 127) {
+                  note -= 12;
+                };
+                mixer_->StopInstrument(i);
+                mixer_->StartInstrument(i, instr, note, false);
+              };
             };
           };
-        };
+        }
       }
     }
 

--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -144,7 +144,7 @@ void View::drawNotes() {
       } else {
         SetColor(CD_HILITE1);
       }
-      if (player->IsRunning()) {
+      if (player->IsRunning() && viewData_->playMode_ != PM_AUDITION) {
         DrawString(pos._x, pos._y, player->GetPlayedNote(i),
                    props); // row for the note values
         pos._y++;

--- a/sources/Application/Views/ChainView.cpp
+++ b/sources/Application/Views/ChainView.cpp
@@ -2,6 +2,7 @@
 #include "Application/Utils/char.h"
 #include "System/Console/Trace.h"
 #include "UIController.h"
+#include "ViewData.h"
 
 ChainView::ChainView(GUIWindow &w, ViewData *viewData) : View(w, viewData) {
   updatingPhrase_ = false;
@@ -756,7 +757,8 @@ void ChainView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
 
     for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
       if (player->IsChannelPlaying(i)) {
-        if (viewData_->currentPlayChain_[i] == viewData_->currentChain_) {
+        if (viewData_->currentPlayChain_[i] == viewData_->currentChain_ &&
+            viewData_->playMode_ != PM_AUDITION) {
           pos._y = anchor._y + viewData_->chainPlayPos_[i];
           if (!player->IsChannelMuted(i)) {
             DrawString(pos._x, pos._y, ">", props);

--- a/sources/Application/Views/GrooveView.cpp
+++ b/sources/Application/Views/GrooveView.cpp
@@ -2,6 +2,7 @@
 #include "GrooveView.h"
 #include "Application/Model/Groove.h"
 #include "Application/Utils/char.h"
+#include "ViewData.h"
 
 GrooveView::GrooveView(GUIWindow &w, ViewData *viewData) : View(w, viewData) {
   position_ = 0;
@@ -208,7 +209,8 @@ void GrooveView::OnPlayerUpdate(PlayerEventType, unsigned int tick) {
 
   gr->GetChannelData(channel, &groove, &groovepos);
 
-  if (groove == viewData_->currentGroove_) {
+  if (groove == viewData_->currentGroove_ &&
+      viewData_->playMode_ != PM_AUDITION) {
     lastPosition_ = groovepos;
     pos._x = anchor._x - 1;
     pos._y = anchor._y + lastPosition_;

--- a/sources/Application/Views/PhraseView.cpp
+++ b/sources/Application/Views/PhraseView.cpp
@@ -5,6 +5,7 @@
 #include "Application/Utils/char.h"
 #include "System/Console/Trace.h"
 #include "UIController.h"
+#include "ViewData.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -18,6 +19,7 @@ PhraseView::PhraseView(GUIWindow &w, ViewData *viewData)
   cmdEditField_ =
       new UIBigHexVarField(pos, cmdEdit_, 4, "%4.4X", 0, 0xFFFF, 16, true);
   row_ = 0;
+  viewData->phraseCurPos_ = 0;
   col_ = 0;
   lastNote_ = 60;
   lastInstr_ = 0;
@@ -98,6 +100,7 @@ void PhraseView::updateCursor(int dx, int dy) {
     break;
   };
 
+  viewData_->phraseCurPos_ = row_;
   isDirty_ = true;
 }
 
@@ -614,6 +617,12 @@ void PhraseView::pasteClipboard() {
   isDirty_ = true;
 };
 
+void PhraseView::stopAudition() {
+  Player *player = Player::GetInstance();
+  if (viewData_->playMode_ == PM_AUDITION)
+    player->Stop();
+}
+
 void PhraseView::unMuteAll() {
 
   UIController *controller = UIController::GetInstance();
@@ -797,7 +806,8 @@ void PhraseView::processNormalButtonMask(unsigned short mask) {
     };
     if (mask & EPBM_R)
       toggleMute();
-
+    if (mask == EPBM_B)
+      stopAudition();
   } else {
 
     // A Modifer
@@ -820,19 +830,32 @@ void PhraseView::processNormalButtonMask(unsigned short mask) {
         if ((col_ == 1) || (col_ == 3) || (col_ == 5))
           viewMode_ = VM_NEW;
       }
-
+      if (col_ == 0 || col_ == 1) {
+        if (player->IsRunning()) {
+          if ((viewData_->playMode_ == PM_AUDITION)) {
+            player->Stop();
+            player->OnStartButton(PM_AUDITION, viewData_->songX_, false,
+                                  viewData_->chainRow_);
+          }
+        } else {
+          player->OnStartButton(PM_AUDITION, viewData_->songX_, false,
+                                viewData_->chainRow_);
+        }
+      }
     } else {
 
       // R Modifier
 
       if (mask & EPBM_R) {
         if (mask & EPBM_LEFT) {
+          stopAudition();
           ViewType vt = VT_CHAIN;
           ViewEvent ve(VET_SWITCH_VIEW, &vt);
           SetChanged();
           NotifyObservers(&ve);
         }
         if (mask & EPBM_RIGHT) {
+          stopAudition();
           unsigned char *c =
               phrase_->instr_ + (16 * viewData_->currentPhrase_ + row_);
           if (*c != 0xFF) {
@@ -848,8 +871,8 @@ void PhraseView::processNormalButtonMask(unsigned short mask) {
           }
         }
         if (mask & EPBM_DOWN) {
-
           // Go to table view
+          stopAudition();
 
           ViewType vt = VT_TABLE;
 
@@ -871,8 +894,8 @@ void PhraseView::processNormalButtonMask(unsigned short mask) {
         }
 
         if (mask & EPBM_UP) {
-
           // Go to groove view
+          stopAudition();
 
           ViewType vt = VT_GROOVE;
           ViewEvent ve(VET_SWITCH_VIEW, &vt);
@@ -1232,7 +1255,8 @@ void PhraseView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
     for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
       if (player->IsChannelPlaying(i)) {
 
-        if (viewData_->currentPlayPhrase_[i] == viewData_->currentPhrase_) {
+        if (viewData_->currentPlayPhrase_[i] == viewData_->currentPhrase_ &&
+            viewData_->playMode_ != PM_AUDITION) {
           pos._y = anchor._y + viewData_->phrasePlayPos_[i];
           if (!player->IsChannelMuted(i)) {
             DrawString(pos._x, pos._y, ">", props);

--- a/sources/Application/Views/PhraseView.cpp
+++ b/sources/Application/Views/PhraseView.cpp
@@ -799,15 +799,18 @@ void PhraseView::processNormalButtonMask(unsigned short mask) {
       warpInChain(-1);
     if (mask & EPBM_DOWN)
       warpInChain(1);
-    if (mask & EPBM_A)
+    if (mask & EPBM_A) {
+      stopAudition();
       cutPosition();
+    }
     if (mask & EPBM_L) {
       viewMode_ = VM_CLONE;
     };
     if (mask & EPBM_R)
       toggleMute();
-    if (mask == EPBM_B)
+    if (mask == EPBM_B) {
       stopAudition();
+    }
   } else {
 
     // A Modifer
@@ -829,17 +832,17 @@ void PhraseView::processNormalButtonMask(unsigned short mask) {
         pasteLast();
         if ((col_ == 1) || (col_ == 3) || (col_ == 5))
           viewMode_ = VM_NEW;
-      }
-      if (col_ == 0 || col_ == 1) {
-        if (player->IsRunning()) {
-          if ((viewData_->playMode_ == PM_AUDITION)) {
-            player->Stop();
+        if (col_ == 0 || col_ == 1) {
+          if (player->IsRunning()) {
+            if ((viewData_->playMode_ == PM_AUDITION)) {
+              player->Stop();
+              player->OnStartButton(PM_AUDITION, viewData_->songX_, false,
+                                    viewData_->chainRow_);
+            }
+          } else {
             player->OnStartButton(PM_AUDITION, viewData_->songX_, false,
                                   viewData_->chainRow_);
           }
-        } else {
-          player->OnStartButton(PM_AUDITION, viewData_->songX_, false,
-                                viewData_->chainRow_);
         }
       }
     } else {

--- a/sources/Application/Views/PhraseView.h
+++ b/sources/Application/Views/PhraseView.h
@@ -36,6 +36,7 @@ protected:
   void cutSelection();
   void pasteClipboard();
 
+  void stopAudition();
   void unMuteAll();
   void toggleMute();
   void switchSoloMode();

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -4,6 +4,7 @@
 #include "System/Console/Trace.h"
 #include "System/System/System.h"
 #include "UIController.h"
+#include "ViewData.h"
 #include <stdlib.h>
 #include <string>
 
@@ -945,7 +946,8 @@ void SongView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
       if (eventType != PET_STOP) {
         if (viewData_->currentPlayChain_[i] != 0xFF) {
           int y = viewData_->songPlayPos_[i] - viewData_->songOffset_;
-          if (y >= 0 && y < View::songRowCount_) {
+          if (y >= 0 && y < View::songRowCount_ &&
+              viewData_->playMode_ != PM_AUDITION) {
             pos._y = anchor._y + y;
             if (!player->IsChannelMuted(i)) {
               DrawString(pos._x, pos._y, ">", props);

--- a/sources/Application/Views/TableView.cpp
+++ b/sources/Application/Views/TableView.cpp
@@ -2,6 +2,7 @@
 #include "Application/Instruments/CommandList.h"
 #include "Application/Player/TablePlayback.h"
 #include "Application/Utils/char.h"
+#include "ViewData.h"
 
 #define FCC_EDIT MAKE_FOURCC('T', 'B', 'E', 'D')
 
@@ -861,7 +862,7 @@ void TableView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
   Table *playbackTable = tpb.GetTable();
   // Table we're viewing
   Table &viewTable = th->GetTable(viewData_->currentTable_);
-  if (playbackTable == &viewTable) {
+  if (playbackTable == &viewTable && viewData_->playMode_ != PM_AUDITION) {
 
     lastPosition_[0] = tpb.GetPlaybackPosition(0);
     lastPosition_[1] = tpb.GetPlaybackPosition(1);

--- a/sources/Application/Views/ViewData.h
+++ b/sources/Application/Views/ViewData.h
@@ -5,7 +5,7 @@
 #include "Application/Model/Project.h"
 #include "System/Console/Trace.h"
 
-enum PlayMode { PM_SONG, PM_CHAIN, PM_PHRASE, PM_LIVE };
+enum PlayMode { PM_SONG, PM_CHAIN, PM_PHRASE, PM_LIVE, PM_AUDITION };
 
 class ViewData {
 
@@ -80,5 +80,6 @@ public:
                                               // channel
   int phrasePlayPos_[SONG_CHANNEL_COUNT]; // .Play position in phrase for each
                                           // channel
+  int phraseCurPos_;                      // current UI cursor row position
 };
 #endif


### PR DESCRIPTION
* Instruments will play when sequencer is stopped
* Play will happen on input of any note or instrument
* Only instruments play, no effects applied.
* Tables and table automation *should* work. Have not tried automation.
* MIDI instruments *should* work, not tested

Code is a bit all over the place and a bit hacky, but probably not too bad. The basic working of this is to start the sequencer every time that we enter a note, but stop the sequencer from advancing and applying effects. Player keeps running indefinitely until we either move away from phrase view, audition another note or start the sequencer in phrase or song view (Play key), as there is not real way to detect that a sound has stopped in any way. This means that any long sample or sound that doesn't end (oscillator loop mode) will play as long as it lasts, potentially forever. Entering another note will stop the previous sound, starting the phrase/song sequencer, moving to another screen or pressing B key, used as an explicit stop (up for suggestions on this one).