### PR TITLE
Limit sample name length to 19 characters

### DIFF
--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -82,7 +82,7 @@ void InstrumentView::fillSampleParameters() {
   position._y -= 1;
   Variable *v = instrument->FindVariable(SIP_SAMPLE);
   SamplePool *sp = SamplePool::GetInstance();
-  UIIntVarField *f1 = new UIIntVarField(position, *v, "sample: %s", 0,
+  UIIntVarField *f1 = new UIIntVarField(position, *v, "sample: %.13s", 0,
                                         sp->GetNameListSize() - 1, 1, 0x10);
   T_SimpleList<UIField>::Insert(f1);
   f1->SetFocus();

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -82,7 +82,7 @@ void InstrumentView::fillSampleParameters() {
   position._y -= 1;
   Variable *v = instrument->FindVariable(SIP_SAMPLE);
   SamplePool *sp = SamplePool::GetInstance();
-  UIIntVarField *f1 = new UIIntVarField(position, *v, "sample: %.13s", 0,
+  UIIntVarField *f1 = new UIIntVarField(position, *v, "sample: %.19s", 0,
                                         sp->GetNameListSize() - 1, 1, 0x10);
   T_SimpleList<UIField>::Insert(f1);
   f1->SetFocus();


### PR DESCRIPTION
This should limit the number of characters displayed for the Sample name on the InstrumentView screen to 19 characters (looks about right)..

Related to https://github.com/democloid/picoTracker/issues/63