### PR TITLE
Update building natively on OSX

### DIFF
--- a/projects/Makefile
+++ b/projects/Makefile
@@ -26,7 +26,7 @@ OSXDIRS := .\
 				../sources/Adapters/OSX/OSXMain \
 				../sources/Adapters/Unix/Process \
 				../sources/System/Process \
-        ../sources/Adapters/SDL/Audio \
+				../sources/Adapters/SDL/Audio \
 				../sources/Adapters/OSX/OSXSystem \
 				../sources/Adapters/SDL/Timer\
 				../sources/Adapters/SDL/GUI \
@@ -65,7 +65,7 @@ COMMONDIRS	:=	../sources/System/Console \
 				../sources/Externals/Soundfont \
 				../sources/Externals/TinyXML \
 				../sources/Externals/TinyXML2 \
-	      ../sources/Externals/yxml \
+				../sources/Externals/yxml \
 
 #---------------------------------------------------------------------------------
 # files definition

--- a/projects/Makefile.OSX
+++ b/projects/Makefile.OSX
@@ -1,9 +1,9 @@
 
 include $(PWD)/osx_rules
 
-CFLAGS  := -O3 -DCPP_MEMORY -w -I$(PWD)/../sources -I/opt/homebrew/include
+CFLAGS  := -O3 -DCPP_MEMORY -w -I$(PWD)/../sources -I$(shell brew --prefix sdl12-compat)/include
 # DEBUG BUILD (use this to debug with lldb)
-#CFLAGS	:= -g -O0 -DCPP_MEMORY -Wall -I$(PWD)/../sources -I/opt/homebrew/Cellar/sdl12-compat/1.2.60/include/ -D_DEBUG -DDEBUG
+#CFLAGS	:= -g -O0 -DCPP_MEMORY -Wall -I$(PWD)/../sources -I$(shell brew --prefix sdl12-compat)/include/ -D_DEBUG -DDEBUG
 
 CXXFLAGS:= $(CFLAGS) -std=c++17
 

--- a/projects/osx_rules
+++ b/projects/osx_rules
@@ -2,5 +2,5 @@
 
 #---------------------------------------------------------------------------------
 %.app: $(OFILES)
-	$(CXX) $(LDFLAGS) -arch arm64 -framework Cocoa -framework Carbon -o $@ $(OFILES) $(LIBS) -L/opt/homebrew/Cellar/sdl12-compat/1.2.60/lib
+	$(CXX) $(LDFLAGS) -arch $(shell uname -m) -framework Cocoa -framework Carbon -o $@ $(OFILES) $(LIBS) -L$(shell brew --prefix sdl12-compat)/lib
 	mv $@ ../lgpt

--- a/sources/System/Console/Trace.cpp
+++ b/sources/System/Console/Trace.cpp
@@ -26,7 +26,7 @@ Trace::Logger *Trace::SetLogger(Trace::Logger &logger) {
 
 //------------------------------------------------------------------------------
 
-void Trace::VLog(const char *category, const char *fmt, const va_list &args) {
+void Trace::VLog(const char *category, const char *fmt, va_list &args) {
   char buffer[256];
   sprintf(buffer, "[%s] ", category);
 

--- a/sources/System/Console/Trace.h
+++ b/sources/System/Console/Trace.h
@@ -30,7 +30,7 @@ public:
   Trace::Logger *SetLogger(Trace::Logger &);
 
 protected:
-  static void VLog(const char *category, const char *fmt, const va_list &args);
+  static void VLog(const char *category, const char *fmt, va_list &args);
 
 private:
   Trace::Logger *logger_;


### PR DESCRIPTION
Just to keep testing on alternate platforms, making it a bit nicer to build on OSX (without breaking current picoTracker build)