### PR TITLE
Limit length of instrument name to 15 characters on Phrase view

### DIFF
--- a/sources/Application/Views/PhraseView.cpp
+++ b/sources/Application/Views/PhraseView.cpp
@@ -1089,6 +1089,8 @@ void PhraseView::DrawView() {
   buffer[0] = 'I';
   buffer[3] = 0;
 
+  char instrumentName[15];
+
   for (int j = 0; j < 16; j++) {
     unsigned char d = *data++;
     setTextProps(props, 1, j, false);
@@ -1105,7 +1107,8 @@ void PhraseView::DrawView() {
         location._x += 12;
         InstrumentBank *bank = viewData_->project_->GetInstrumentBank();
         I_Instrument *instr = bank->GetInstrument(d);
-        instrLine += instr->GetName();
+        sprintf(instrumentName, "%.15s", instr->GetName());
+        instrLine += instrumentName;
         DrawString(location._x, location._y, instrLine.c_str(), props);
       }
     }


### PR DESCRIPTION
This should limit the name of the instruments on the Phrase view to 15 characters which is the maximum we can view without wrapping.

Related to https://github.com/democloid/picoTracker/issues/88

I don't believe we should remove the space before to give us an extra couple of characters.