### PR TITLE
Set status to Importing dir when importing samples

### DIFF
--- a/sources/Application/Instruments/SamplePool.cpp
+++ b/sources/Application/Instruments/SamplePool.cpp
@@ -159,9 +159,6 @@ bool SamplePool::loadSample(const char *path) {
   if (count_ == MAX_PIG_SAMPLES)
     return false;
 
-  Path sPath(path);
-  Status::Set("Loading %s", sPath.GetName().c_str());
-
   Path wavPath(path);
   WavFile *wave = WavFile::Open(path);
   if (wave) {
@@ -196,7 +193,7 @@ int SamplePool::ImportSample(Path &path) {
   dpath += path.GetName();
   Path dstPath(dpath.c_str());
 
-  Status::Set("Importing %s", path.GetName().c_str());
+  Status::Set("Loading %s", path.GetName().c_str());
 
   // Opens files
 

--- a/sources/Application/Instruments/SamplePool.cpp
+++ b/sources/Application/Instruments/SamplePool.cpp
@@ -196,6 +196,8 @@ int SamplePool::ImportSample(Path &path) {
   dpath += path.GetName();
   Path dstPath(dpath.c_str());
 
+  Status::Set("Importing %s", path.GetName().c_str());
+
   // Opens files
 
   I_File *fin = FileSystem::GetInstance()->Open(path.GetPath().c_str(), "r");


### PR DESCRIPTION
Shows a status message when importing samples to avoid the delay before it actually starts loading the samples.

Fixes: https://github.com/democloid/picoTracker/issues/40