### PR TITLE
Stripping the file extension on Sample Import

### DIFF
--- a/sources/Application/Instruments/SamplePool.cpp
+++ b/sources/Application/Instruments/SamplePool.cpp
@@ -168,7 +168,10 @@ bool SamplePool::loadSample(const char *path) {
     wav_[count_] = wave;
     std::string name = wavPath.GetName();
     // Drop file extension
-    name.resize(name.length() - 4);
+    size_t index = name.find_last_of(".");
+    if (index < name.length() && index > 0) {
+      name.resize(index);
+    }
     names_[count_] = (char *)SYS_MALLOC(name.length() + 1);
     strcpy(names_[count_], name.c_str());
     count_++;

--- a/sources/Application/Instruments/SamplePool.cpp
+++ b/sources/Application/Instruments/SamplePool.cpp
@@ -169,9 +169,7 @@ bool SamplePool::loadSample(const char *path) {
     std::string name = wavPath.GetName();
     // Drop file extension
     size_t index = name.find_last_of(".");
-    if (index < name.length() && index > 0) {
-      name.resize(index);
-    }
+    name = name.substr(0, index);
     names_[count_] = (char *)SYS_MALLOC(name.length() + 1);
     strcpy(names_[count_], name.c_str());
     count_++;

--- a/sources/Application/Instruments/SamplePool.cpp
+++ b/sources/Application/Instruments/SamplePool.cpp
@@ -166,7 +166,9 @@ bool SamplePool::loadSample(const char *path) {
   WavFile *wave = WavFile::Open(path);
   if (wave) {
     wav_[count_] = wave;
-    const std::string name = wavPath.GetName();
+    std::string name = wavPath.GetName();
+    // Drop file extension
+    name.resize(name.length() - 4);
     names_[count_] = (char *)SYS_MALLOC(name.length() + 1);
     strcpy(names_[count_], name.c_str());
     count_++;


### PR DESCRIPTION
Removes file extension when importing the sample in the simplest way possible.

Fixes: https://github.com/democloid/picoTracker/issues/88