### PR TITLE
Build number for GitHub CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,12 @@ jobs:
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
       run: PICO_SDK_PATH=../sources/Externals/pico-sdk PICO_TOOLCHAIN_PATH=${{steps.arm-none-eabi-gcc-action.outputs.path}} cmake ../sources -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
+    - name: Set Build Number
+      shell: bash
+      env:
+          GH_RUN_NUMBER: ${{ github.run_number }}
+      run: echo "#define BUILD_COUNT \"$GH_RUN_NUMBER\"" > sources/Application/Model/BuildNumber.h
+
     - name: Get core count
       id: core_count
       run : cat /proc/cpuinfo  | grep processor | wc -l

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,4 +55,8 @@ jobs:
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE --parallel $(nproc)
+    - uses: actions/upload-artifact@v4
+      with:
+        name: picoTracker-uf2
+        path: ${{github.workspace}}/build/Adapters/picoTracker/main/picoTracker.uf2 
 

--- a/sources/Application/Model/BuildNumber.h
+++ b/sources/Application/Model/BuildNumber.h
@@ -1,0 +1,1 @@
+#define BUILD_COUNT "003"

--- a/sources/Application/Model/Project.h
+++ b/sources/Application/Model/Project.h
@@ -7,6 +7,7 @@
 #include "Foundation/Types/Types.h"
 #include "Foundation/Variables/VariableContainer.h"
 #include "Song.h"
+#include "BuildNumber.h"
 
 #define VAR_TEMPO MAKE_FOURCC('T', 'M', 'P', 'O')
 #define VAR_MASTERVOL MAKE_FOURCC('M', 'S', 'T', 'R')
@@ -17,7 +18,7 @@
 
 #define PROJECT_NUMBER "1.0"
 #define PROJECT_RELEASE "r"
-#define BUILD_COUNT "003"
+// BUILD_COUNT define comes from BuildNumber.h
 
 #define MAX_TAP 3
 

--- a/sources/Application/Model/Project.h
+++ b/sources/Application/Model/Project.h
@@ -3,11 +3,11 @@
 
 #include "Application/Instruments/InstrumentBank.h"
 #include "Application/Persistency/Persistent.h"
+#include "BuildNumber.h"
 #include "Foundation/Observable.h"
 #include "Foundation/Types/Types.h"
 #include "Foundation/Variables/VariableContainer.h"
 #include "Song.h"
-#include "BuildNumber.h"
 
 #define VAR_TEMPO MAKE_FOURCC('T', 'M', 'P', 'O')
 #define VAR_MASTERVOL MAKE_FOURCC('M', 'S', 'T', 'R')


### PR DESCRIPTION
This sets the build number on each GitHub CI workflow run using the GitHub Actions run number. 
It also uploads the built uf2 binary to make it available after the workflow completes.

Fixes: #100, #50