### PR TITLE
Remove filename extension in sample instrument getName()

### DIFF
--- a/sources/Application/Instruments/I_Instrument.h
+++ b/sources/Application/Instruments/I_Instrument.h
@@ -40,7 +40,7 @@ public:
 
   virtual InstrumentType GetType() = 0;
 
-  virtual const char *GetName() = 0;
+  virtual std::string GetName() = 0;
 
   virtual void ProcessCommand(int channel, FourCC cc, ushort value) = 0;
 

--- a/sources/Application/Instruments/MidiInstrument.cpp
+++ b/sources/Application/Instruments/MidiInstrument.cpp
@@ -172,10 +172,10 @@ void MidiInstrument::ProcessCommand(int channel, FourCC cc, ushort value) {
   }
 };
 
-const char *MidiInstrument::GetName() {
+std::string MidiInstrument::GetName() {
   Variable *v = FindVariable(MIP_CHANNEL);
   sprintf(name_, "MIDI CH %2.2d", v->GetInt() + 1);
-  return name_;
+  return std::string(name_);
 }
 
 int MidiInstrument::GetTable() {

--- a/sources/Application/Instruments/MidiInstrument.h
+++ b/sources/Application/Instruments/MidiInstrument.h
@@ -40,7 +40,7 @@ public:
 
   virtual InstrumentType GetType() { return IT_MIDI; };
 
-  virtual const char *GetName();
+  virtual std::string GetName();
 
   virtual void OnStart();
 

--- a/sources/Application/Instruments/SampleInstrument.cpp
+++ b/sources/Application/Instruments/SampleInstrument.cpp
@@ -1354,10 +1354,13 @@ void SampleInstrument::ProcessCommand(int channel, FourCC cc, ushort value) {
   };
 };
 
-const char *SampleInstrument::GetName() {
+std::string SampleInstrument::GetName() {
 
   Variable *v = FindVariable(SIP_SAMPLE);
-  return v->GetString();
+  std::string name = v->GetString();
+  // Drop file extension
+  size_t index = name.find_last_of(".");
+  return name.substr(0, index);
 };
 
 void SampleInstrument::Purge() {

--- a/sources/Application/Instruments/SampleInstrument.h
+++ b/sources/Application/Instruments/SampleInstrument.h
@@ -84,7 +84,7 @@ public:
   int GetVolume();
   void SetVolume(int);
   int GetSampleSize(int channel = -1);
-  virtual const char *GetName(); // returns sample name until real
+  virtual std::string GetName(); // returns sample name until real
                                  // namer is implemented
 
   static void EnableDownsamplingLegacy();

--- a/sources/Application/Views/PhraseView.cpp
+++ b/sources/Application/Views/PhraseView.cpp
@@ -1134,7 +1134,7 @@ void PhraseView::DrawView() {
         location._x += 12;
         InstrumentBank *bank = viewData_->project_->GetInstrumentBank();
         I_Instrument *instr = bank->GetInstrument(d);
-        sprintf(instrumentName, "%.15s", instr->GetName());
+        sprintf(instrumentName, "%.15s", instr->GetName().c_str());
         instrLine += instrumentName;
         DrawString(location._x, location._y, instrLine.c_str(), props);
       }


### PR DESCRIPTION
This PR changes the extension removal code to be in the SampleInstrument's getName() as it needs to do it here and not in Samplepool as there the real filename must be used.

Unfortunately this needed more code change than would otherwise have been necessary in order to use C++'s return by value with string objects in the Instrument interface, instead of returning a char* buffer as `getName()` previously did, as for that the caller would then need to free that returned buffer which goes against the usual C way of passing in any buffer that needs to contain a string returned from the called function.

Fixes: #88 