### PR TITLE
Fix sample import screen file listing

### DIFF
--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
@@ -37,9 +37,7 @@ void picoTrackerPagedDir::GetContent(const char *mask) {
   FsBaseFile entry;
 
   // Insert a parent dir path given that FatFS doesn't provide it
-  PathIndex pi;
-  pi.index = 0;
-  pi.type = ParentDirIndex;
+  PathIndex pi = {0, ParentDirIndex};
   fileIndexes_.push_back(pi);
 
   while (entry.openNext(&dir, O_READ)) {

--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
@@ -5,26 +5,22 @@
 
 #include <string>
 
-#define MAGIC_PARENT_DIR_INDEX_MARKER -1
-
 // Max filename is actually 256 per FAT std
 static const int MAX_FILENAME_LEN = 128;
 
 picoTrackerPagedDir::picoTrackerPagedDir(const char *path)
     : path_{std::string(path)} {
   // Initial size allocation for file and subdir entries per each dir
-  // these act as "soft limits" since while the Vector objects will allocate
+  // this act as "soft limit" since while the Vector object will allocate
   // more room if the initially allocated space is used up, this will likely
   // exhaust available RAM per my testing as of making this change
-  fileIndexes_.reserve(354);
-  subdirIndexes_.reserve(96);
+  fileIndexes_.reserve(320);
 };
 
 void picoTrackerPagedDir::GetContent(const char *mask) {
   Trace::Log("PAGEDFILESYSTEM", "GetContent path:%s mask:%s", path_.c_str(),
              mask);
   fileIndexes_.clear();
-  subdirIndexes_.clear();
   FsBaseFile dir;
 
   if (!dir.open(path_.c_str())) {
@@ -41,26 +37,35 @@ void picoTrackerPagedDir::GetContent(const char *mask) {
   FsBaseFile entry;
 
   // Insert a parent dir path given that FatFS doesn't provide it
-  subdirIndexes_.push_back(MAGIC_PARENT_DIR_INDEX_MARKER);
+  PathIndex pi;
+  pi.index = 0;
+  pi.type = ParentDirIndex;
+  fileIndexes_.push_back(pi);
 
   while (entry.openNext(&dir, O_READ)) {
     char current[MAX_FILENAME_SIZE];
     entry.getName(current, MAX_FILENAME_SIZE);
 
-    int fileIndex = entry.dirIndex();
+    pi.index = entry.dirIndex();
     if (entry.isDir()) {
-      subdirIndexes_.push_back(fileIndex);
+      pi.type = DirIndex;
+      fileIndexes_.push_back(pi);
     } else if (wildcardfit(mask, current)) {
-      fileIndexes_.push_back(fileIndex);
+      pi.type = FileIndex;
+      fileIndexes_.push_back(pi);
+    } else {
+      Trace::Log("PAGEDFILESYSTEM", "%s wildcard miss idx:%d", current,
+                 pi.index);
     }
     count++;
   }
-  fileCount_ = subdirIndexes_.size() + fileIndexes_.size();
-  Trace::Log("PAGEDFILESYSTEM", "scanned %d files", count);
+  fileCount_ = fileIndexes_.size();
+  Trace::Log("PAGEDFILESYSTEM", "scanned %d files add entries:", count,
+             fileCount_);
 }
 
 std::string picoTrackerPagedDir::getFullName(int index) {
-  if (index == MAGIC_PARENT_DIR_INDEX_MARKER) {
+  if (fileIndexes_[index].type == ParentDirIndex) {
     return "..";
   }
 
@@ -98,32 +103,29 @@ void picoTrackerPagedDir::getFileList(int startOffset,
   char current[MAX_FILENAME_LEN];
   FsBaseFile file;
 
-  unsigned int count = startOffset;
-  for (; count < subdirIndexes_.size() && (fileList->size() < PAGED_PAGE_SIZE);
+  for (size_t count = startOffset;
+       count < fileIndexes_.size() && (fileList->size() < PAGED_PAGE_SIZE);
        count++) {
-    int index = subdirIndexes_[count];
+    auto indexEntry = fileIndexes_[count];
 
     // add synthetic entry for the parent directory
-    if (startOffset == 0 && count == 0) {
+    if (indexEntry.type == ParentDirIndex) {
       strcpy(current, "..");
     } else {
-      if (!file.open(&dir, index, O_READ)) {
-        Trace::Error("PAGEDFILESYSTEM Failed to getfile at Index %d", index);
+      if (!file.open(&dir, indexEntry.index, O_READ)) {
+        Trace::Error("PAGEDFILESYSTEM Failed to getfile at Index %d",
+                     indexEntry.index);
       }
       file.getName(current, MAX_FILENAME_LEN);
-      current[23] = 0; // truncate at 22 char length string
+      // dirs get max len of 2 less than files becase they are shown surrounded
+      // with "[]"
+      current[indexEntry.type == DirIndex ? 23 : 25] =
+          0; // truncate at 22 char length string
     }
-    fileList->push_back(FileListItem(current, index, true));
-  }
-  for (; count < fileIndexes_.size() && (fileList->size() < PAGED_PAGE_SIZE);
-       count++) {
-    int index = fileIndexes_[count];
-    if (!file.open(&dir, index, O_READ)) {
-      Trace::Error("PAGEDFILESYSTEM Failed to getfile at Index %d", index);
-    }
-    file.getName(current, MAX_FILENAME_LEN);
-    current[25] = 0; // truncate at 24 char length string
-    fileList->push_back(FileListItem(current, index, false));
+    Trace::Log("PAGEDFILESYSTEM", "push file:%s|%d [%d]", current,
+               indexEntry.index, indexEntry.type);
+    fileList->push_back(FileListItem(current, indexEntry.index,
+                                     (indexEntry.type != FileIndex)));
   }
 }
 

--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.h
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.h
@@ -7,6 +7,17 @@
 #include <string.h>
 #include <vector>
 
+enum PathIndexTypes {
+  ParentDirIndex,
+  DirIndex,
+  FileIndex,
+};
+
+struct PathIndex {
+  unsigned short index;
+  char type;
+};
+
 class picoTrackerFile : public I_File {
 public:
   picoTrackerFile(FsBaseFile file);
@@ -43,8 +54,7 @@ public:
 
 private:
   const std::string path_;
-  std::vector<int> fileIndexes_{};
-  std::vector<int> subdirIndexes_{};
+  std::vector<PathIndex> fileIndexes_{};
 };
 
 class picoTrackerFileSystem : public FileSystem {

--- a/sources/Adapters/picoTracker/sdcard/sd_card_spi.cpp
+++ b/sources/Adapters/picoTracker/sdcard/sd_card_spi.cpp
@@ -32,10 +32,12 @@ public:
   }
 
   void activate() {
+    #if SHOW_SPI_DEBUG
     uint baudrate = spi_init(SD_SPI, m_sckfreq);
-    if (false) {
-      Trace::Log("SDCARD", "SD SPI baudrate: %i\n", baudrate);
-    }
+    Trace::Log("SDCARD", "SD SPI baudrate: %i\n", baudrate);
+    #else
+    spi_init(SD_SPI, m_sckfreq);
+    #endif
     spi_set_format(SD_SPI, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
   }
 

--- a/sources/Adapters/picoTracker/sdcard/sd_card_spi.cpp
+++ b/sources/Adapters/picoTracker/sdcard/sd_card_spi.cpp
@@ -32,12 +32,12 @@ public:
   }
 
   void activate() {
-    #if SHOW_SPI_DEBUG
+#if SHOW_SPI_DEBUG
     uint baudrate = spi_init(SD_SPI, m_sckfreq);
     Trace::Log("SDCARD", "SD SPI baudrate: %i\n", baudrate);
-    #else
+#else
     spi_init(SD_SPI, m_sckfreq);
-    #endif
+#endif
     spi_set_format(SD_SPI, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
   }
 

--- a/sources/Adapters/picoTracker/sdcard/sd_card_spi.cpp
+++ b/sources/Adapters/picoTracker/sdcard/sd_card_spi.cpp
@@ -1,6 +1,7 @@
 // Driver and interface for accessing SD card in SPI mode
 
 #include "Adapters/picoTracker/platform/platform.h"
+#include "System/Console/Trace.h"
 #include <SdFat.h>
 #include <cstdio>
 #include <hardware/gpio.h>
@@ -32,7 +33,9 @@ public:
 
   void activate() {
     uint baudrate = spi_init(SD_SPI, m_sckfreq);
-    printf("SD SPI baudrate: %i\n", baudrate);
+    if (false) {
+      Trace::Log("SDCARD", "SD SPI baudrate: %i\n", baudrate);
+    }
     spi_set_format(SD_SPI, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
   }
 

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -21,6 +21,7 @@ add_definitions(-DPICOBUILD)
 # add_definitions(-DPICOSTATS)
 # add_definitions(-DALL_MALLOC)
 # add_definitions(-DSHOW_MEM_USAGE)
+# add_definitions(-DSHOW_SPI_DEBUG)
 add_definitions(-DDISABLESF)
 # Enable SDIO - this setting affects code in SdFat library as well as the project
 # This consumes ~7k+ RAM and has some performance problems ATM


### PR DESCRIPTION
The previous logic to handle file+subdir index listings was incorrect, as it would incorrectly index the file entry indexes list in an attempt to handle paging with a combination of the subdir list and the file list.

Instead of trying to make things work with the 2 separate lists, the code has been simplified to just use a single list for both subdirs and files within a directory by using a struct that holds both an directory entries Filesystem driver index and its type (parent, subdir or file).  I think this is a bit less memory efficient than having the 2 separate lists, but makes the code simpler and more robust.

This also includes a tiny change to tone down the debug logging from the SPI code.

Fixes: #83