### PR TITLE
Adding option to use old sound driver for lineout use

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -24,18 +24,21 @@ The `samplelib` folder at the root of the SD card is where picoTracker will look
 
 ## config.xml
 
-A `config.xml` file can be placed on the root of the SD card. The only configuration options right now are the interface colors and setting the keymap "style". 
+A `config.xml` file can be placed on the root of the SD card. The only configuration options right now are the interface colors, setting the keymap "style" and setting the sound output for easy listening or loud.
 
 This is an example config file:
 ```
 <CONFIG>
     <BACKGROUND value="0F0F0F" />
     <FOREGROUND value="ADADAD" /> <!-- text and cursor in cursor -->
-	<HICOLOR1 value="846F94" /> <!-- row count in song screen -->
-	<HICOLOR2 value="6B316B" /> <!-- cursor-->
+    <HICOLOR1 value="846F94" /> <!-- row count in song screen -->
+    <HICOLOR2 value="6B316B" /> <!-- cursor-->
     <KEYMAPSTYLE value="M8" /> <!-- use M8 style keymap layout -->
+    <SOUNDOUTPUT value="LINEOUT" /> <!-- use louder lineout driver for greater volume from the sound output jack -->
 </CONFIG>
 ```
+
+With sound output, any value other than "LINEOUT" (including not being specified) for the `SOUNDOUTPUT` setting will have the effect of selecting the default "Headphone" output which is lower for a safer listening experience.
 
 The "M8 style" keymap is as shown below:
 

--- a/sources/Adapters/picoTracker/audio/CMakeLists.txt
+++ b/sources/Adapters/picoTracker/audio/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(platform_audio
 )
 
 pico_generate_pio_header(platform_audio ${CMAKE_CURRENT_LIST_DIR}/audio_i2s.pio)
+pico_generate_pio_header(platform_audio ${CMAKE_CURRENT_LIST_DIR}/audio_lineout_i2s.pio)
 
 target_link_libraries(platform_audio PUBLIC pico_stdlib
                                      PUBLIC pico_multicore

--- a/sources/Adapters/picoTracker/audio/audio_lineout_i2s.pio
+++ b/sources/Adapters/picoTracker/audio/audio_lineout_i2s.pio
@@ -1,0 +1,63 @@
+;
+; Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+;
+; SPDX-License-Identifier: BSD-3-Clause
+;
+
+; Transmit a mono or stereo I2S audio stream as stereo
+; This is 16 bits per sample; can be altered by modifying the "set" params,
+; or made programmable by replacing "set x" with "mov x, y" and using Y as a config register.
+;
+; Autopull must be enabled, with threshold set to 32.
+; Since I2S is MSB-first, shift direction should be to left.
+; Hence the format of the FIFO word is:
+;
+; | 31   :   16 | 15   :    0 |
+; | sample ws=0 | sample ws=1 |
+;
+; Data is output at 1 bit per clock. Use clock divider to adjust frequency.
+; Fractional divider will probably be needed to get correct bit clock period,
+; but for common syslck freqs this should still give a constant word select period.
+;
+; One output pin is used for the data output.
+; Two side-set pins are used. Bit 0 is clock, bit 1 is word select.
+
+; Send 16 bit words to the PIO for mono, 32 bit words for stereo
+
+.program audio_lineout_i2s
+.side_set 2
+
+                    ;        /--- LRCLK
+                    ;        |/-- BCLK
+bitloop1:           ;        ||
+    out pins, 1       side 0b10
+    jmp x-- bitloop1  side 0b11
+    out pins, 1       side 0b00
+    set x, 14         side 0b01
+
+bitloop0:
+    out pins, 1       side 0b00
+    jmp x-- bitloop0  side 0b01
+    out pins, 1       side 0b10
+public entry_point:
+    set x, 14 side 0b11    
+
+% c-sdk {
+
+static inline void audio_lineout_i2s_program_init(PIO pio, uint sm, uint offset, uint data_pin, uint clock_pin_base) {
+    pio_sm_config sm_config = audio_lineout_i2s_program_get_default_config(offset);
+    
+    sm_config_set_out_pins(&sm_config, data_pin, 1);
+    sm_config_set_sideset_pins(&sm_config, clock_pin_base);
+    sm_config_set_out_shift(&sm_config, false, true, 32);
+
+    pio_sm_init(pio, sm, offset, &sm_config);
+
+    uint pin_mask = (1u << data_pin) | (3u << clock_pin_base);
+    pio_sm_set_pindirs_with_mask(pio, sm, pin_mask, pin_mask);
+    pio_sm_set_pins(pio, sm, 0); // clear pins
+
+    pio_sm_exec(pio, sm, pio_encode_jmp(offset + audio_lineout_i2s_offset_entry_point));
+}
+
+%}

--- a/sources/Application/Model/Config.cpp
+++ b/sources/Application/Model/Config.cpp
@@ -25,7 +25,8 @@ Config::Config() {
         strcmp(doc.ElemName(), "FOREGROUND") &&
         strcmp(doc.ElemName(), "HICOLOR1") &&
         strcmp(doc.ElemName(), "HICOLOR2") &&
-        strcmp(doc.ElemName(), "KEYMAPSTYLE")) {
+        strcmp(doc.ElemName(), "KEYMAPSTYLE") &&
+        strcmp(doc.ElemName(), "SOUNDOUTPUT")) {
       Trace::Log("CONFIG", "Found unknown config parameter \"%s\", skipping...",
                  doc.ElemName());
       validElem = false;


### PR DESCRIPTION
Changes needed to implement old driver to allow louder sound output available via the Config

Fixes: https://github.com/democloid/picoTracker/issues/110

This allows both a low impedance headphone friendly default driver (by @maks) and then the ability to use the original *loud* audio driver (by @democloid) by setting a value in `config.xml`

Just add ```<SOUNDOUTPUT value="LINEOUT" />``` to turn it on, remove that or change the value to anything else to turn it off.

The reasoning for this, has been a chat on the #beta-testers channel in Discord, and this seems to be the best compromise for the moment to cater for both the headphone crowd and studio crowd.

I've implemented this because I know @maks has a lot on his plate in regards to other issues.