### PR TITLE
Add battery gauge display

### DIFF
--- a/sources/Adapters/picoTracker/platform/gpio.h
+++ b/sources/Adapters/picoTracker/platform/gpio.h
@@ -9,6 +9,9 @@
 #define DISPLAY_SCK 26
 #define DISPLAY_MOSI 27
 
+// BATT ADC
+#define BATT_VOLTAGE_IN_PIN 29
+
 // Midi (UART1)
 #define MIDI_UART uart0
 #define MIDI_BAUD_RATE 31250

--- a/sources/Adapters/picoTracker/platform/gpio.h
+++ b/sources/Adapters/picoTracker/platform/gpio.h
@@ -10,7 +10,7 @@
 #define DISPLAY_MOSI 27
 
 // BATT ADC
-#define BATT_VOLTAGE_IN_PIN 29
+#define BATT_VOLTAGE_IN 29
 
 // Midi (UART1)
 #define MIDI_UART uart0

--- a/sources/Adapters/picoTracker/system/CMakeLists.txt
+++ b/sources/Adapters/picoTracker/system/CMakeLists.txt
@@ -14,7 +14,12 @@ target_link_libraries(platform_system INTERFACE system_system
                                       PUBLIC platform_gui
                                       PUBLIC platform_display
                                       PUBLIC dummy_midi
+                                      PUBLIC pico_stdlib
+                                      PUBLIC hardware_gpio
+                                      PUBLIC hardware_adc
+
 )
+
 
 target_include_directories(platform_system PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
@@ -133,15 +133,12 @@ int picoTrackerSystem::GetBatteryLevel() {
   unsigned int beatCount = SyncMaster::GetInstance()->GetBeatCount();
   if (beatCount != lastBeatCount_) {
     u_int16_t adc_reading = adc_read(); // raw voltage from ADC
-    printf("ADC READING: %d ", adc_reading);
+    //printf("ADC READING: %d ", adc_reading);
 
     int adc_voltage = adc_reading * 0.8; // 0.8mV per unit of ADC
-
     // *2 because picoTracker use voltage divider for voltage on ADC pin
     lastBattLevel_ = adc_voltage * 2;
-    
-    printf("BATTERY: %d ", lastBattLevel_);
-
+    //printf("BATTERY: %d ", lastBattLevel_);
     lastBeatCount_ = beatCount;
   }
 

--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
@@ -13,6 +13,7 @@
 #include "Application/Model/Config.h"
 #include "Application/Player/SyncMaster.h"
 #include "System/Console/Logger.h"
+#include "hardware/gpio.h"
 #include "input.h"
 #include <assert.h>
 #include <fcntl.h>
@@ -24,8 +25,8 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "Adapters/picoTracker/platform/platform.h"
 #include "hardware/adc.h"
-#include "hardware/gpio.h"
 #include "pico/stdlib.h"
 
 EventManager *picoTrackerSystem::eventManager_ = NULL;
@@ -98,16 +99,14 @@ void picoTrackerSystem::Boot(int argc, char **argv) {
   eventManager_->MapAppButton("up", APP_BUTTON_UP);
 
   // init GPIO for use as ADC: hi-Z, no pullups, etc
-  adc_gpio_init(29);
+  adc_gpio_init(BATT_VOLTAGE_IN);
 
   adc_init();
 
   // select analog MUX, GPIO 26=0, 27=1, 28=1, 29=3
   adc_select_input(3);
 
-  // TODO: use BATT_VOLTAGE_IN_PIN from platform/gpio.h instead of hardcoding
-  // pin number here
-  printf("ADC INIT DONE\n");
+  Trace::Log("PICOTRACKERSYSTEM", "ADC INIT DONE\n");
 
   //  mode0_print("boot successful");
 };
@@ -138,7 +137,6 @@ int picoTrackerSystem::GetBatteryLevel() {
     int adc_voltage = adc_reading * 0.8; // 0.8mV per unit of ADC
     // *2 because picoTracker use voltage divider for voltage on ADC pin
     lastBattLevel_ = adc_voltage * 2;
-    // printf("BATTERY: %d ", lastBattLevel_);
     lastBeatCount_ = beatCount;
   }
 

--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
@@ -133,12 +133,12 @@ int picoTrackerSystem::GetBatteryLevel() {
   unsigned int beatCount = SyncMaster::GetInstance()->GetBeatCount();
   if (beatCount != lastBeatCount_) {
     u_int16_t adc_reading = adc_read(); // raw voltage from ADC
-    //printf("ADC READING: %d ", adc_reading);
+    // printf("ADC READING: %d ", adc_reading);
 
     int adc_voltage = adc_reading * 0.8; // 0.8mV per unit of ADC
     // *2 because picoTracker use voltage divider for voltage on ADC pin
     lastBattLevel_ = adc_voltage * 2;
-    //printf("BATTERY: %d ", lastBattLevel_);
+    // printf("BATTERY: %d ", lastBattLevel_);
     lastBeatCount_ = beatCount;
   }
 

--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
@@ -141,8 +141,12 @@ int picoTrackerSystem::GetBatteryLevel() {
   if (beatCount != lastBeatCount_) {
     adc_capture(sample_buf, N_SAMPLES);
 
-    printf("BATTERY: %d", sample_buf[0]);
-    lastBattLevel_ = sample_buf[0];
+    printf("ADC READING: %d", sample_buf[0]);
+    int adc_reading = sample_buf[0];
+    int adc_voltage = adc_reading * 0.8; //0.8mV per unit of ADC
+
+    lastBattLevel_ =  adc_voltage * 2; //because picoTracker use voltage divider for voltage on ADC pin
+    printf("BATTERY: %d", lastBattLevel_);
 
     lastBeatCount_ = beatCount;
   }

--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
@@ -132,7 +132,6 @@ int picoTrackerSystem::GetBatteryLevel() {
   unsigned int beatCount = SyncMaster::GetInstance()->GetBeatCount();
   if (beatCount != lastBeatCount_) {
     u_int16_t adc_reading = adc_read(); // raw voltage from ADC
-    // printf("ADC READING: %d ", adc_reading);
 
     int adc_voltage = adc_reading * 0.8; // 0.8mV per unit of ADC
     // *2 because picoTracker use voltage divider for voltage on ADC pin

--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
@@ -24,15 +24,14 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "pico/stdlib.h"
+#include "hardware/gpio.h"
+#include "hardware/adc.h"
+
 EventManager *picoTrackerSystem::eventManager_ = NULL;
 bool picoTrackerSystem::invert_ = false;
 int picoTrackerSystem::lastBattLevel_ = 100;
 unsigned int picoTrackerSystem::lastBeatCount_ = 0;
-
-static FILE *devbatt_;
-static char *strval;
-static size_t n;
-static size_t t;
 
 int picoTrackerSystem::MainLoop() {
 
@@ -97,12 +96,17 @@ void picoTrackerSystem::Boot(int argc, char **argv) {
   eventManager_->MapAppButton("left", APP_BUTTON_LEFT);
   eventManager_->MapAppButton("down", APP_BUTTON_DOWN);
   eventManager_->MapAppButton("up", APP_BUTTON_UP);
+
+  adc_init();
+  //TODO: use BATT_VOLTAGE_IN_PIN from platform/gpio.h instead of hardcoding pin number here
+  gpio_set_dir(29, GPIO_IN);
+  printf("ADC INIT DONE\n");
+
   //  mode0_print("boot successful");
 };
 
 void picoTrackerSystem::Shutdown() {
   delete Audio::GetInstance();
-  fclose(devbatt_);
 };
 
 static int secbase;
@@ -118,27 +122,34 @@ unsigned long picoTrackerSystem::GetClock() {
   return long((tp.tv_sec - secbase) * 1000 + tp.tv_usec / 1000.0);
 }
 
+#define N_SAMPLES 1
+uint16_t sample_buf[N_SAMPLES];
+
+void __not_in_flash_func(adc_capture)(uint16_t *buf, size_t count) {
+    adc_fifo_setup(true, false, 0, false, false);
+    adc_run(true);
+    for (size_t i = 0; i < count; i = i + 1)
+        buf[i] = adc_fifo_get_blocking();
+    adc_run(false);
+    adc_fifo_drain();
+}
+
 int picoTrackerSystem::GetBatteryLevel() {
 
-  if (0) {
-    unsigned int beatCount = SyncMaster::GetInstance()->GetBeatCount();
-    if (beatCount != lastBeatCount_) {
-      unsigned short currentval = 0;
-      fseek(devbatt_, 0, SEEK_SET);
-      fread(strval, t, n, devbatt_);
-      currentval = atoi(strval);
-      if (currentval > 4000)
-        currentval = 4000;
-      if (currentval < 3000)
-        currentval = 3000;
-      lastBattLevel_ = ((currentval - 3000) / 10);
-      lastBeatCount_ = beatCount;
-    }
-  } else {
-    lastBattLevel_ = -1;
+  int lastBattLevel_ = -1;
+  unsigned int beatCount = SyncMaster::GetInstance()->GetBeatCount();
+  if (beatCount != lastBeatCount_) {
+    adc_capture(sample_buf, N_SAMPLES);
+
+    printf("BATTERY: %d", sample_buf[0]);
+    lastBattLevel_ = sample_buf[0];
+
+    lastBeatCount_ = beatCount;
   }
+  
   return lastBattLevel_;
-};
+}
+
 
 void picoTrackerSystem::Sleep(int millisec) {
   //	if (millisec>0)

--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -123,7 +123,7 @@ AppWindow::~AppWindow() { MidiService::GetInstance()->Close(); }
 void AppWindow::DrawString(const char *string, GUIPoint &pos,
                            GUITextProperties &props, bool force) {
 
-  // we know we don't have mode than 40 chars
+  // we know we don't have more than 40 chars
 
   char buffer[41];
   int len = strlen(string);

--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -225,26 +225,26 @@ void View::DrawString(int x, int y, const char *txt, GUITextProperties &props) {
 void View::drawBattery(float voltage, GUIPoint &pos, GUITextProperties &props) {
   if (voltage >= 0) {
     if (voltage <= 3.4) {
-      SetColor(CD_HILITE2); //TODO: change to CD_ERROR once its available
+      SetColor(CD_HILITE2); // TODO: change to CD_ERROR once its available
     } else {
       SetColor(CD_HILITE1);
     }
 
-    char* battText;
+    char *battText;
     if (voltage > 4.0) {
-      battText = (char*)"[++F]";
-      //TODO: check for if charging and then show [+C]
+      battText = (char *)"[++F]";
+      // TODO: check for if charging and then show [+C]
     } else if (voltage > 3.6) {
-      battText = (char*)"[+++]";
+      battText = (char *)"[+++]";
     } else if (voltage > 3.5) {
-      battText = (char*)"[++ ]";
+      battText = (char *)"[++ ]";
     } else if (voltage > 3.4) {
-      battText = (char*)"[+  ]";
+      battText = (char *)"[+  ]";
     } else {
-      battText = (char*)"[   ]";
+      battText = (char *)"[   ]";
     }
 
     // printf("%.1fV %s", voltage, battText);
-    DrawString(pos._x, pos._y, battText, props) ;
+    DrawString(pos._x, pos._y, battText, props);
   }
 }

--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -221,3 +221,30 @@ void View::DrawString(int x, int y, const char *txt, GUITextProperties &props) {
   GUIPoint pos(x, y);
   w_.DrawString(txt, pos, props);
 };
+
+void View::drawBattery(float voltage, GUIPoint &pos, GUITextProperties &props) {
+  if (voltage >= 0) {
+    if (voltage <= 3.4) {
+      SetColor(CD_HILITE2); //TODO: change to CD_ERROR once its available
+    } else {
+      SetColor(CD_HILITE1);
+    }
+
+    char* battText;
+    if (voltage > 4.0) {
+      battText = (char*)"[++F]";
+      //TODO: check for if charging and then show [+C]
+    } else if (voltage > 3.6) {
+      battText = (char*)"[+++]";
+    } else if (voltage > 3.5) {
+      battText = (char*)"[++ ]";
+    } else if (voltage > 3.4) {
+      battText = (char*)"[+  ]";
+    } else {
+      battText = (char*)"[   ]";
+    }
+
+    // printf("%.1fV %s", voltage, battText);
+    DrawString(pos._x, pos._y, battText, props) ;
+  }
+}

--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -244,7 +244,6 @@ void View::drawBattery(float voltage, GUIPoint &pos, GUITextProperties &props) {
       battText = (char *)"[   ]";
     }
 
-    // printf("%.1fV %s", voltage, battText);
     DrawString(pos._x, pos._y, battText, props);
   }
 }

--- a/sources/Application/Views/BaseClasses/View.h
+++ b/sources/Application/Views/BaseClasses/View.h
@@ -130,6 +130,8 @@ protected:
   void drawMap();
   void drawNotes();
 
+  void drawBattery(float voltage, GUIPoint &pos, GUITextProperties &props);
+
 public: // temp hack for modl windo constructors
   GUIWindow &w_;
   ViewData *viewData_;

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -998,26 +998,26 @@ void SongView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
   }
 
   char strbuffer[10];
-  
   pos._y+=1 ;
-        sprintf(strbuffer,"%3.3d%%",player->GetPlayedBufferPercentage()) ;
-        DrawString(pos._x,pos._y,strbuffer,props) ;
+  sprintf(strbuffer,"%3.3d%%",player->GetPlayedBufferPercentage()) ;
+  DrawString(pos._x,pos._y,strbuffer,props) ;
 
-    System *sys=System::GetInstance() ;
-    int batt=sys->GetBatteryLevel() ;
-    if (batt>=0) {
-                if (batt<90) {
-                        SetColor(CD_HILITE2) ;
-                        invertBatt_=!invertBatt_ ;
-                } else {
-                        invertBatt_=false ;
-                } ;
-                props.invert_=invertBatt_ ;
-
-            pos._y+=1 ;
-        sprintf(strbuffer,"%3.3d",batt) ;
-            DrawString(pos._x,pos._y,strbuffer,props) ;
+  System *sys=System::GetInstance();
+  float batt = sys->GetBatteryLevel() / 1000.0;
+  if (batt >= 0) {
+    if (batt < 3.4) {
+      SetColor(CD_HILITE2);
+      invertBatt_ = !invertBatt_;
+    } else {
+      invertBatt_ = false;
     }
+    props.invert_ = invertBatt_;
+
+    pos._y += 1;
+
+    sprintf(strbuffer, "%3.1fV", batt);
+    DrawString(pos._x, pos._y, strbuffer, props) ;
+  }
   
   if (eventType != PET_STOP) {
     SetColor(CD_NORMAL);
@@ -1029,5 +1029,6 @@ void SongView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
     pos._y += 1;
     DrawString(pos._x, pos._y, strbuffer, props);
   }
+
   drawNotes();
 };

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -998,7 +998,7 @@ void SongView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
   }
 
   char strbuffer[10];
-  /*
+  
   pos._y+=1 ;
         sprintf(strbuffer,"%3.3d%%",player->GetPlayedBufferPercentage()) ;
         DrawString(pos._x,pos._y,strbuffer,props) ;
@@ -1018,7 +1018,7 @@ void SongView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
         sprintf(strbuffer,"%3.3d",batt) ;
             DrawString(pos._x,pos._y,strbuffer,props) ;
     }
-  */
+  
   if (eventType != PET_STOP) {
     SetColor(CD_NORMAL);
     props.invert_ = false;

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -998,11 +998,11 @@ void SongView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
 
   char strbuffer[10];
 
-  System *sys=System::GetInstance();
+  System *sys = System::GetInstance();
   float batt = sys->GetBatteryLevel() / 1000.0;
   pos._y += 1;
   drawBattery(batt, pos, props);
-  
+
   if (eventType != PET_STOP) {
     SetColor(CD_NORMAL);
     props.invert_ = false;
@@ -1016,4 +1016,3 @@ void SongView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
 
   drawNotes();
 };
-

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -25,7 +25,6 @@ SongView::SongView(GUIWindow &w, ViewData *viewData, const char *song)
   }
   clipboard_.active_ = false;
   clipboard_.data_ = 0;
-  invertBatt_ = false;
 }
 
 /****************
@@ -1001,21 +1000,8 @@ void SongView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
 
   System *sys=System::GetInstance();
   float batt = sys->GetBatteryLevel() / 1000.0;
-  if (batt >= 0) {
-    if (batt < 3.4) {
-      SetColor(CD_HILITE2);
-      invertBatt_ = !invertBatt_;
-    } else {
-      SetColor(CD_HILITE1);
-      invertBatt_ = false;
-    }
-    props.invert_ = invertBatt_;
-
-    pos._y += 1;
-
-    sprintf(strbuffer, "%.1fV ", batt);
-    DrawString(pos._x, pos._y, strbuffer, props) ;
-  }
+  pos._y += 1;
+  drawBattery(batt, pos, props);
   
   if (eventType != PET_STOP) {
     SetColor(CD_NORMAL);
@@ -1030,3 +1016,4 @@ void SongView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
 
   drawNotes();
 };
+

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -998,9 +998,6 @@ void SongView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
   }
 
   char strbuffer[10];
-  pos._y+=1 ;
-  sprintf(strbuffer,"%3.3d%%",player->GetPlayedBufferPercentage()) ;
-  DrawString(pos._x,pos._y,strbuffer,props) ;
 
   System *sys=System::GetInstance();
   float batt = sys->GetBatteryLevel() / 1000.0;
@@ -1009,13 +1006,14 @@ void SongView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
       SetColor(CD_HILITE2);
       invertBatt_ = !invertBatt_;
     } else {
+      SetColor(CD_HILITE1);
       invertBatt_ = false;
     }
     props.invert_ = invertBatt_;
 
     pos._y += 1;
 
-    sprintf(strbuffer, "%3.1fV", batt);
+    sprintf(strbuffer, "%.1fV ", batt);
     DrawString(pos._x, pos._y, strbuffer, props) ;
   }
   

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -33,7 +33,7 @@ add_definitions(-DDISABLESF)
 # Enable loading samples into Flash
 add_definitions(-DLOAD_IN_FLASH)
 # Disable MIDI. Enable in order to use UART0 as stdio for debugging
-# add_definitions(-DDUMMY_MIDI)
+add_definitions(-DDUMMY_MIDI)
 # Disable feedback for sample instruments. Due to low memory in the PICO
 # there is very low chance to bring this back
 add_definitions(-DDISABLE_FEEDBACK)
@@ -80,7 +80,7 @@ target_compile_definitions(picoTracker PUBLIC
 #endif()
 
 # Debug output with USB uses +6K memory
-pico_enable_stdio_usb(${PROJECT_NAME} 0)
+pico_enable_stdio_usb(${PROJECT_NAME} 1)
 pico_enable_stdio_uart(${PROJECT_NAME} 0)
 
 # This is the default, but better to make it explicit

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -33,7 +33,7 @@ add_definitions(-DDISABLESF)
 # Enable loading samples into Flash
 add_definitions(-DLOAD_IN_FLASH)
 # Disable MIDI. Enable in order to use UART0 as stdio for debugging
-add_definitions(-DDUMMY_MIDI)
+# add_definitions(-DDUMMY_MIDI)
 # Disable feedback for sample instruments. Due to low memory in the PICO
 # there is very low chance to bring this back
 add_definitions(-DDISABLE_FEEDBACK)
@@ -80,7 +80,7 @@ target_compile_definitions(picoTracker PUBLIC
 #endif()
 
 # Debug output with USB uses +6K memory
-pico_enable_stdio_usb(${PROJECT_NAME} 1)
+pico_enable_stdio_usb(${PROJECT_NAME} 0)
 pico_enable_stdio_uart(${PROJECT_NAME} 0)
 
 # This is the default, but better to make it explicit


### PR DESCRIPTION
This adds a simple battery gauge display.

For now its only using the previously existing (unused) battery display functionality: so only on the Song screen and only updated every beat only when project is playing back.

The voltage levels used for each "state" of the gauge were determined approximately based on a run down test (timelapse video below).

The intention is to iterate on this in followup PRs to use better mechanism for scheduling reading batt level updates, show gauge on all screens, define a new "CD_ERROR" colour for use when batt level critical and improve the ascii art of the gauge display.

The current state of the gauge UI is:


![batt-gauge](https://github.com/democloid/picoTracker/assets/71999/22f933e1-0da3-4077-996c-97b1d2cc9d8f)

https://github.com/democloid/picoTracker/assets/71999/67a114db-2435-4ef6-b4e2-bc895244b924

