### PR TITLE
Add colours

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -33,6 +33,11 @@ This is an example config file:
     <FOREGROUND value="ADADAD" /> <!-- text and cursor in cursor -->
 	<HICOLOR1 value="846F94" /> <!-- row count in song screen -->
 	<HICOLOR2 value="6B316B" /> <!-- cursor-->
+    <INFOCOLOR value="33EE33"> <!-- information displays eg. used for battery gauge ok level -->
+    <WARNCOLOR value="11EE22"> <!-- warning displays eg. battery gauge low level -->
+    <ERRORCOLOR value="FF1111"> <!-- error displays eg. battery gauge critical level -->
+    <CURSORCOLOR value="224400"> <!-- TODO -->
+    <CONSOLECOLOR value="99FFAA"> <!-- TODO -->
     <KEYMAPSTYLE value="M8" /> <!-- use M8 style keymap layout -->
 </CONFIG>
 ```

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -32,12 +32,12 @@ This is an example config file:
     <BACKGROUND value="0F0F0F" />
     <FOREGROUND value="ADADAD" /> <!-- text and cursor in cursor -->
 	<HICOLOR1 value="846F94" /> <!-- row count in song screen -->
-	<HICOLOR2 value="6B316B" /> <!-- cursor-->
+	<HICOLOR2 value="6B316B" />  <!-- inverted highlight, eg. "Song" screen label -->
     <INFOCOLOR value="33EE33"> <!-- information displays eg. used for battery gauge ok level -->
     <WARNCOLOR value="11EE22"> <!-- warning displays eg. battery gauge low level -->
     <ERRORCOLOR value="FF1111"> <!-- error displays eg. battery gauge critical level -->
-    <CURSORCOLOR value="224400"> <!-- TODO -->
-    <CONSOLECOLOR value="99FFAA"> <!-- TODO -->
+    <CURSORCOLOR value="224400">  <!-- ?? -->
+    <CONSOLECOLOR value="99FFAA"> <!-- ?? -->
     <KEYMAPSTYLE value="M8" /> <!-- use M8 style keymap layout -->
 </CONFIG>
 ```

--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -97,12 +97,16 @@ AppWindow::AppWindow(I_GUIWindowImp &imp) : GUIWindow(imp) {
   // Init midi services
   MidiService::GetInstance()->Init();
 
+  // now assign custom colors if they have been set in the config.xml
   defineColor("BACKGROUND", backgroundColor_, 0);
   defineColor("FOREGROUND", normalColor_, 1);
   cursorColor_ = normalColor_;
   defineColor("HICOLOR1", highlightColor_, 2);
   defineColor("HICOLOR2", highlight2Color_, 3);
   defineColor("CURSORCOLOR", cursorColor_, 4);
+  defineColor("INFOCOLOR", infoColor_, 5);
+  defineColor("WARNCOLOR", warnColor_, 6);
+  defineColor("ERRORCOLOR", errorColor_, 7);
 
   GUIWindow::Clear(backgroundColor_);
 
@@ -241,10 +245,10 @@ void AppWindow::Flush() {
             break;
           case CD_WARN:
             gcolor = warnColor_;
-            break;    
+            break;
           case CD_ERROR:
             gcolor = errorColor_;
-            break;  
+            break;
 
           default:
             NAssert(0);

--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -29,6 +29,9 @@ GUIColor AppWindow::highlightColor_(0x84, 0x6F, 0x94, 2);
 GUIColor AppWindow::highlight2Color_(0x6B, 0x31, 0x6B, 3);
 GUIColor AppWindow::cursorColor_(0x77, 0x6B, 0x56, 4);
 GUIColor AppWindow::consoleColor_(0xFF, 0x00, 0xFF, 5);
+GUIColor AppWindow::infoColor_(0x29, 0xEE, 0x3D, 6);
+GUIColor AppWindow::warnColor_(0xEF, 0xFA, 0x52, 7);
+GUIColor AppWindow::errorColor_(0xE8, 0x4D, 0x15, 8);
 
 int AppWindow::charWidth_ = 8;
 int AppWindow::charHeight_ = 8;
@@ -233,6 +236,15 @@ void AppWindow::Flush() {
           case CD_CURSOR:
             gcolor = cursorColor_;
             break;
+          case CD_INFO:
+            gcolor = infoColor_;
+            break;
+          case CD_WARN:
+            gcolor = warnColor_;
+            break;    
+          case CD_ERROR:
+            gcolor = errorColor_;
+            break;  
 
           default:
             NAssert(0);

--- a/sources/Application/AppWindow.h
+++ b/sources/Application/AppWindow.h
@@ -96,6 +96,9 @@ private:
   static GUIColor highlightColor_;
   static GUIColor consoleColor_;
   static GUIColor cursorColor_;
+  static GUIColor infoColor_;
+  static GUIColor warnColor_;
+  static GUIColor errorColor_;
 
   ColorDefinition colorIndex_;
 

--- a/sources/Application/Model/Config.cpp
+++ b/sources/Application/Model/Config.cpp
@@ -25,6 +25,11 @@ Config::Config() {
         strcmp(doc.ElemName(), "FOREGROUND") &&
         strcmp(doc.ElemName(), "HICOLOR1") &&
         strcmp(doc.ElemName(), "HICOLOR2") &&
+        strcmp(doc.ElemName(), "CONSOLECOLOR") &&
+        strcmp(doc.ElemName(), "CURSORCOLOR") &&
+        strcmp(doc.ElemName(), "INFOCOLOR") &&
+        strcmp(doc.ElemName(), "WARNCOLOR") &&
+        strcmp(doc.ElemName(), "ERRORCOLOR") &&
         strcmp(doc.ElemName(), "KEYMAPSTYLE")) {
       Trace::Log("CONFIG", "Found unknown config parameter \"%s\", skipping...",
                  doc.ElemName());

--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -224,12 +224,8 @@ void View::DrawString(int x, int y, const char *txt, GUITextProperties &props) {
 
 void View::drawBattery(float voltage, GUIPoint &pos, GUITextProperties &props) {
   if (voltage >= 0) {
-    if (voltage <= 3.4) {
-      SetColor(CD_HILITE2); // TODO: change to CD_ERROR once its available
-    } else {
-      SetColor(CD_HILITE1);
-    }
-
+    SetColor(CD_INFO);
+    
     char *battText;
     if (voltage > 4.0) {
       battText = (char *)"[++F]";
@@ -239,8 +235,10 @@ void View::drawBattery(float voltage, GUIPoint &pos, GUITextProperties &props) {
     } else if (voltage > 3.5) {
       battText = (char *)"[++ ]";
     } else if (voltage > 3.4) {
+      SetColor(CD_WARN);
       battText = (char *)"[+  ]";
     } else {
+      SetColor(CD_ERROR);
       battText = (char *)"[   ]";
     }
 

--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -225,7 +225,7 @@ void View::DrawString(int x, int y, const char *txt, GUITextProperties &props) {
 void View::drawBattery(float voltage, GUIPoint &pos, GUITextProperties &props) {
   if (voltage >= 0) {
     SetColor(CD_INFO);
-    
+
     char *battText;
     if (voltage > 4.0) {
       battText = (char *)"[++F]";

--- a/sources/Application/Views/BaseClasses/View.h
+++ b/sources/Application/Views/BaseClasses/View.h
@@ -53,7 +53,10 @@ enum ColorDefinition {
   CD_HILITE1,
   CD_HILITE2,
   CD_CONSOLE,
-  CD_CURSOR
+  CD_CURSOR,
+  CD_INFO,
+  CD_WARN,
+  CD_ERROR
 };
 
 enum ViewUpdateDirection { VUD_LEFT = 0, VUD_RIGHT, VUD_UP, VUD_DOWN };


### PR DESCRIPTION
This adds 3 new system color definitions: INFO, WARN and ERROR.
It makes use of the new colors for drawing the battery gauge at different states of discharge.
These colors can also be set to values other than the default hardcoded values with in config.xml and the example `config.xml` in the Manual has been updated.

This also exposes to 2 colors "CURSOR" and "CONSOLE" that were previously defined in the code but not documented in the manual and not exposed for user configuration via config.xml though it seems that these are not used as per their naming, eg. the CURSOR color is not actually used for drawing the cursor at the moment.

Note: this is currently stacked on the main loop timer PR branch.

Fixes: #128 