### PR TITLE
Show flash usage

### DIFF
--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
@@ -62,7 +62,7 @@ void picoTrackerPagedDir::GetContent(const char *mask) {
              fileCount_);
 }
 
-int32_t picoTrackerPagedDir::getFileSize(int index){
+int32_t picoTrackerPagedDir::getFileSize(int index) {
   if (fileIndexes_[index].type == ParentDirIndex) {
     Trace::Error("parentdir index, no filesize");
     return 0;
@@ -80,7 +80,8 @@ int32_t picoTrackerPagedDir::getFileSize(int index){
   FsBaseFile file;
 
   if (!file.open(&dir, index, O_READ)) {
-    Trace::Error("PAGEDFILESYSTEM Failed to getfile at Index %d for getSize", index);
+    Trace::Error("PAGEDFILESYSTEM Failed to getfile at Index %d for getSize",
+                 index);
     return 0;
   }
 

--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
@@ -62,6 +62,31 @@ void picoTrackerPagedDir::GetContent(const char *mask) {
              fileCount_);
 }
 
+int32_t picoTrackerPagedDir::getFileSize(int index){
+  if (fileIndexes_[index].type == ParentDirIndex) {
+    Trace::Error("parentdir index, no filesize");
+    return 0;
+  }
+
+  FsBaseFile dir;
+  if (!dir.open(path_.c_str())) {
+    Trace::Error("getFileSize failed open:%s", path_.c_str());
+    return 0;
+  }
+  if (!dir.isDir()) {
+    Trace::Error("Path:%s is not a directory", path_.c_str());
+    return 0;
+  }
+  FsBaseFile file;
+
+  if (!file.open(&dir, index, O_READ)) {
+    Trace::Error("PAGEDFILESYSTEM Failed to getfile at Index %d for getSize", index);
+    return 0;
+  }
+
+  return file.fileSize();
+}
+
 std::string picoTrackerPagedDir::getFullName(int index) {
   if (fileIndexes_[index].type == ParentDirIndex) {
     return "..";

--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.h
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.h
@@ -51,6 +51,7 @@ public:
   std::string getFullName(int index);
   void getFileList(int startIndex, std::vector<FileListItem> *fileList);
   int size();
+  int32_t getFileSize(int index);
 
 private:
   const std::string path_;

--- a/sources/Adapters/picoTracker/utils/CMakeLists.txt
+++ b/sources/Adapters/picoTracker/utils/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(platform_utils
   utils.h utils.cpp
+  stringutils.h stringutils.cpp
 )
 
 target_link_libraries(platform_utils PUBLIC pico_stdlib

--- a/sources/Adapters/picoTracker/utils/stringutils.cpp
+++ b/sources/Adapters/picoTracker/utils/stringutils.cpp
@@ -4,13 +4,10 @@
 
 // The result of the function must be freed
 // ref: https://stackoverflow.com/a/77278639/85472
-char *humanMemorySize(uint32_t bytes) {
-  char *result = (char *)malloc(sizeof(char) * 20);
+void humanMemorySize(uint32_t bytes, char *output) {
   const char *const sizeNames[] = {"B", "KB", "MB", "GB"};
 
   uint32_t i = (uint32_t)floor(log(bytes) / log(1024));
   float humanSize = bytes / pow(1024, i);
-  snprintf(result, sizeof(char) * 12, "%.1f%s", humanSize, sizeNames[i]);
-
-  return result;
+  snprintf(output, sizeof(char) * 12, "%.1f%s", humanSize, sizeNames[i]);
 }

--- a/sources/Adapters/picoTracker/utils/stringutils.cpp
+++ b/sources/Adapters/picoTracker/utils/stringutils.cpp
@@ -2,7 +2,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-// The result of the function must be freed
 // ref: https://stackoverflow.com/a/77278639/85472
 void humanMemorySize(uint32_t bytes, char *output) {
   const char *const sizeNames[] = {"B", "KB", "MB", "GB"};

--- a/sources/Adapters/picoTracker/utils/stringutils.cpp
+++ b/sources/Adapters/picoTracker/utils/stringutils.cpp
@@ -9,8 +9,8 @@ char *humanMemorySize(uint32_t bytes) {
   const char *const sizeNames[] = {"B", "KB", "MB", "GB"};
 
   uint32_t i = (uint32_t)floor(log(bytes) / log(1024));
-  double humanSize = bytes / pow(1024, i);
-  snprintf(result, sizeof(char) * 20, "%g %s", humanSize, sizeNames[i]);
+  float humanSize = bytes / pow(1024, i);
+  snprintf(result, sizeof(char) * 12, "%.1f%s", humanSize, sizeNames[i]);
 
   return result;
 }

--- a/sources/Adapters/picoTracker/utils/stringutils.cpp
+++ b/sources/Adapters/picoTracker/utils/stringutils.cpp
@@ -1,0 +1,16 @@
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// The result of the function must be freed
+// ref: https://stackoverflow.com/a/77278639/85472
+char *humanMemorySize(uint32_t bytes) {
+  char *result = (char *)malloc(sizeof(char) * 20);
+  const char *const sizeNames[] = {"B", "KB", "MB", "GB"};
+
+  uint32_t i = (uint32_t)floor(log(bytes) / log(1024));
+  double humanSize = bytes / pow(1024, i);
+  snprintf(result, sizeof(char) * 20, "%g %s", humanSize, sizeNames[i]);
+
+  return result;
+}

--- a/sources/Adapters/picoTracker/utils/stringutils.h
+++ b/sources/Adapters/picoTracker/utils/stringutils.h
@@ -1,0 +1,6 @@
+#ifndef _STRINGUTILS_H_
+#define _STRINGUTILS_H_
+
+char *humanMemorySize(uint32_t bytes);
+
+#endif

--- a/sources/Adapters/picoTracker/utils/stringutils.h
+++ b/sources/Adapters/picoTracker/utils/stringutils.h
@@ -1,6 +1,6 @@
 #ifndef _STRINGUTILS_H_
 #define _STRINGUTILS_H_
 
-char *humanMemorySize(uint32_t bytes);
+void humanMemorySize(uint32_t bytes, char *buffer);
 
 #endif

--- a/sources/Application/Instruments/SamplePool.cpp
+++ b/sources/Application/Instruments/SamplePool.cpp
@@ -16,8 +16,7 @@
 //  WARNING! should be conscious to always ensure 1MB of free space
 extern char __flash_binary_end;
 #define FLASH_TARGET_OFFSET                                                    \
-  ((((uintptr_t) & __flash_binary_end - 0x10000000u) / FLASH_SECTOR_SIZE) +    \
-   1) *                                                                        \
+  ((((uintptr_t)&__flash_binary_end - 0x10000000u) / FLASH_SECTOR_SIZE) + 1) * \
       FLASH_SECTOR_SIZE
 // #define FLASH_LIMIT (2 * 1024 * 1024)
 

--- a/sources/Application/Instruments/SamplePool.cpp
+++ b/sources/Application/Instruments/SamplePool.cpp
@@ -31,6 +31,10 @@ int SamplePool::flashLimit_ =
 #define FLASH_RUID_TOTAL_BYTES                                                 \
   (1 + FLASH_RUID_DUMMY_BYTES + FLASH_RUID_DATA_BYTES)
 
+int SamplePool::flashUsage() {
+  return flashLimit_ - flashWriteOffset_;
+}
+
 #endif
 
 #ifdef PICOBUILD

--- a/sources/Application/Instruments/SamplePool.cpp
+++ b/sources/Application/Instruments/SamplePool.cpp
@@ -16,7 +16,8 @@
 //  WARNING! should be conscious to always ensure 1MB of free space
 extern char __flash_binary_end;
 #define FLASH_TARGET_OFFSET                                                    \
-  ((((uintptr_t)&__flash_binary_end - 0x10000000u) / FLASH_SECTOR_SIZE) + 1) * \
+  ((((uintptr_t) & __flash_binary_end - 0x10000000u) / FLASH_SECTOR_SIZE) +    \
+   1) *                                                                        \
       FLASH_SECTOR_SIZE
 // #define FLASH_LIMIT (2 * 1024 * 1024)
 
@@ -31,9 +32,7 @@ int SamplePool::flashLimit_ =
 #define FLASH_RUID_TOTAL_BYTES                                                 \
   (1 + FLASH_RUID_DUMMY_BYTES + FLASH_RUID_DATA_BYTES)
 
-int SamplePool::flashUsage() {
-  return flashLimit_ - flashWriteOffset_;
-}
+int SamplePool::flashUsage() { return flashLimit_ - flashWriteOffset_; }
 
 #endif
 

--- a/sources/Application/Instruments/SamplePool.h
+++ b/sources/Application/Instruments/SamplePool.h
@@ -30,7 +30,7 @@ public:
   const char *GetSampleLib();
 #ifdef LOAD_IN_FLASH
   int flashUsage();
-#endif  
+#endif
 
 protected:
   bool loadSample(const char *path);

--- a/sources/Application/Instruments/SamplePool.h
+++ b/sources/Application/Instruments/SamplePool.h
@@ -28,6 +28,9 @@ public:
   int ImportSample(Path &path);
   void PurgeSample(int i);
   const char *GetSampleLib();
+#ifdef LOAD_IN_FLASH
+  int flashUsage();
+#endif  
 
 protected:
   bool loadSample(const char *path);

--- a/sources/Application/Views/ModalDialogs/CMakeLists.txt
+++ b/sources/Application/Views/ModalDialogs/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(application_views_modaldialogs
 
 target_link_libraries(application_views_modaldialogs PUBLIC application_views_baseclasses
                                                      PUBLIC pico_multicore
+                                                     PUBLIC platform_utils
   
 )
 

--- a/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
@@ -69,10 +69,21 @@ void PagedImportSampleDialog::DrawView() {
   SamplePool *pool = SamplePool::GetInstance();
   char statusbar[33];
   SetColor(CD_NORMAL);
+  
+  int charsAdded = 0;
+  // get filesize of currently highlighted file
+  FileListItem currentItem = fileList_[currentSample_ - topIndex_];
+  auto fileSize = currentDir_->getFileSize(currentItem.index);
+  if (fileSize > 0) {
+    auto fileSizeStr = humanMemorySize(fileSize);
+    charsAdded = sprintf(statusbar, "FILE:%s ", fileSizeStr);
+    delete fileSizeStr;
+  }
+  
   auto usage = humanMemorySize(pool->flashUsage());
-  sprintf(statusbar, "FREE: [%s]", usage);
+  sprintf(statusbar+charsAdded, "FREE:[%s]", usage);
   delete usage;
-  GUIPoint pos = GUIPoint(0, 23);
+  GUIPoint pos = GUIPoint(2, 23);
   w_.DrawString(statusbar, pos, props);
 };
 

--- a/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
@@ -1,6 +1,8 @@
 #include "PagedImportSampleDialog.h"
+#include "Adapters/picoTracker/utils/stringutils.h"
 #include "Application/Instruments/SampleInstrument.h"
 #include "Application/Instruments/SamplePool.h"
+
 #ifdef PICOBUILD
 #include "pico/multicore.h"
 #endif
@@ -57,8 +59,8 @@ void PagedImportSampleDialog::DrawView() {
       strncpy(buffer + 1, current.name.c_str(), LIST_WIDTH - 2);
       strcat(buffer, "]");
     }
-    buffer[LIST_WIDTH] =
-        0; // make sure if truncated the filename we have trailing null
+    // make sure if truncated the filename we have trailing null
+    buffer[LIST_WIDTH] = 0;
     DrawString(x, y, buffer, props);
     y += 1;
     count++;
@@ -67,7 +69,9 @@ void PagedImportSampleDialog::DrawView() {
   SamplePool *pool = SamplePool::GetInstance();
   char statusbar[33];
   SetColor(CD_NORMAL);
-  sprintf(statusbar, "FLASH: [%d]", pool->flashUsage());
+  auto usage = humanMemorySize(pool->flashUsage());
+  sprintf(statusbar, "FREE: [%s]", usage);
+  delete usage;
   GUIPoint pos = GUIPoint(0, 23);
   w_.DrawString(statusbar, pos, props);
 };

--- a/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
@@ -69,7 +69,7 @@ void PagedImportSampleDialog::DrawView() {
   SamplePool *pool = SamplePool::GetInstance();
   char statusbar[33];
   SetColor(CD_NORMAL);
-  
+
   int charsAdded = 0;
   // get filesize of currently highlighted file
   FileListItem currentItem = fileList_[currentSample_ - topIndex_];
@@ -79,9 +79,9 @@ void PagedImportSampleDialog::DrawView() {
     charsAdded = sprintf(statusbar, "FILE:%s ", fileSizeStr);
     delete fileSizeStr;
   }
-  
+
   auto usage = humanMemorySize(pool->flashUsage());
-  sprintf(statusbar+charsAdded, "FREE:[%s]", usage);
+  sprintf(statusbar + charsAdded, "FREE:[%s]", usage);
   delete usage;
   GUIPoint pos = GUIPoint(2, 23);
   w_.DrawString(statusbar, pos, props);

--- a/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
@@ -21,12 +21,13 @@ void PagedImportSampleDialog::DrawView() {
   Trace::Log("PAGEDIMPORT", "DrawView current:%d topIdx:%d", currentSample_,
              topIndex_);
 
-  SetWindow(LIST_WIDTH, PAGED_PAGE_SIZE);
+  // SetWindow(LIST_WIDTH, PAGED_PAGE_SIZE);
+  SetWindow(30, 22);
   GUITextProperties props;
 
 // Draw title
 #ifdef SHOW_MEM_USAGE
-  char title[40];
+  char title[33];
 
   SetColor(CD_NORMAL);
 
@@ -63,7 +64,12 @@ void PagedImportSampleDialog::DrawView() {
     count++;
   };
 
+  SamplePool *pool = SamplePool::GetInstance();
+  char statusbar[33];
   SetColor(CD_NORMAL);
+  sprintf(statusbar, "FLASH: [%d]", pool->flashUsage());
+  GUIPoint pos = GUIPoint(0, 23);
+  w_.DrawString(statusbar, pos, props);
 };
 
 void PagedImportSampleDialog::warpToNextSample(int direction) {

--- a/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
@@ -69,7 +69,7 @@ void PagedImportSampleDialog::DrawView() {
 
   SamplePool *pool = SamplePool::GetInstance();
   etl::string<33> statusbar;
-  statusbar.initialize_free_space(); 
+  statusbar.initialize_free_space();
 
   SetColor(CD_NORMAL);
 
@@ -88,7 +88,8 @@ void PagedImportSampleDialog::DrawView() {
   humanMemorySize(pool->flashUsage(), unitsFormatted.data());
   unitsFormatted.trim_to_terminator();
 
-  statusbar.uninitialized_resize(statusbar.max_size()); // Make the string as big as it can be.
+  statusbar.uninitialized_resize(
+      statusbar.max_size()); // Make the string as big as it can be.
   statusbar.trim_to_terminator();
 
   sprintf(statusbar.data_end(), "FREE:[%s]", unitsFormatted.data());

--- a/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
@@ -74,15 +74,14 @@ void PagedImportSampleDialog::DrawView() {
   // get filesize of currently highlighted file
   FileListItem currentItem = fileList_[currentSample_ - topIndex_];
   auto fileSize = currentDir_->getFileSize(currentItem.index);
+  char *unitsFormatted = (char *)malloc(sizeof(char) * 10);
   if (fileSize > 0) {
-    auto fileSizeStr = humanMemorySize(fileSize);
-    charsAdded = sprintf(statusbar, "FILE:%s ", fileSizeStr);
-    delete fileSizeStr;
+    humanMemorySize(fileSize, unitsFormatted);
+    charsAdded = sprintf(statusbar, "FILE:%s ", unitsFormatted);
   }
 
-  auto usage = humanMemorySize(pool->flashUsage());
-  sprintf(statusbar + charsAdded, "FREE:[%s]", usage);
-  delete usage;
+  humanMemorySize(pool->flashUsage(), unitsFormatted);
+  sprintf(statusbar + charsAdded, "FREE:[%s]", unitsFormatted);
   GUIPoint pos = GUIPoint(2, 23);
   w_.DrawString(statusbar, pos, props);
 };

--- a/sources/System/FileSystem/FileSystem.h
+++ b/sources/System/FileSystem/FileSystem.h
@@ -129,6 +129,7 @@ public:
   virtual void getFileList(int startIndex,
                            std::vector<FileListItem> *fileList) = 0;
   virtual int size() = 0;
+  virtual int32_t getFileSize(int index) = 0;
 
 protected:
   unsigned int fileCount_ = 0;


### PR DESCRIPTION
This adds a "statusbar" at the bottom of the sample import screen that shows the size of the currently selected file and the total remaining space in Flash storage for the current project, formated to B, KB or MB.

The free amount will update as samples are imported into the project.

Also there could probably be a bit of tidy up in `picoTrackerPagedDir` to factor out opening a dir into a separate private method as this code has now been copy/pasted a couple of times into diff places in the class.

Note during testing this uncovered an existing bug where some file list entries are incorrectly being assigned the "parent dir" type, but that will be fixed in a separate PR.

![PXL_20240218_100243659](https://github.com/democloid/picoTracker/assets/71999/e91852b6-7dfc-4efe-b9c0-6bef21657cd4)

Fixes: #132 