### PR TITLE
Pico sdk version update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       uses: carlosperate/arm-none-eabi-gcc-action@v1
       id: arm-none-eabi-gcc-action
       with:
-        release: 13.2.Rel1
+        release: 12.3.Rel1
     - run: arm-none-eabi-gcc --version
 
     - name: Create Build Environment

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       uses: carlosperate/arm-none-eabi-gcc-action@v1
       id: arm-none-eabi-gcc-action
       with:
-        release: 10.3-2021.07
+        release: 13.2.Rel1
     - run: arm-none-eabi-gcc --version
 
     - name: Create Build Environment


### PR DESCRIPTION
Update pico sdk release again. This time CI updated to gcc 13.2 to hopefully catch any future regressions on the pico sdk submodule version.