### PR TITLE
Fix maximum flash size of 2MB

### DIFF
--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -67,6 +67,7 @@ target_compile_definitions(picoTracker PUBLIC
   PICO_STACK_SIZE=4096
   PICO_CORE1_STACK_SIZE=4096 # Safe value. 2K seems to be enough. Is it for all use cases?
   PICO_USE_STACK_GUARDS
+  PICO_FLASH_SIZE_BYTES=16*1024*1024
   # workaround for slow init crystal on some boards see: https://github.com/raspberrypi/pico-sdk/pull/457
   PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64
 )


### PR DESCRIPTION
Turns out there was an assert in the pico-sdk checking for PICO_FLASH_SIZE_BYTES which defaults to 2MB if not set, so once we detected higher amount of flash and tried to write to it, we hit the assert. Set it now to the maximum possible (16MB) and use internal logic to detect actual size. Tested on picoTracker hardware and on Raspberry Pi Pico.