### PR TITLE
Make LoadInFlash func not be in flash for added safety

### DIFF
--- a/sources/Application/Instruments/WavFile.cpp
+++ b/sources/Application/Instruments/WavFile.cpp
@@ -308,8 +308,9 @@ bool WavFile::GetBuffer(long start, long size) {
 };
 
 #ifdef LOAD_IN_FLASH
-bool WavFile::LoadInFlash(int &flashEraseOffset, int &flashWriteOffset,
-                          int &flashLimit) {
+bool __not_in_flash_func(WavFile::LoadInFlash)(int &flashEraseOffset,
+                                               int &flashWriteOffset,
+                                               int &flashLimit) {
 
   // Size needed in flash before accounting for page size
   int FlashBaseBufferSize = 2 * channelCount_ * size_;


### PR DESCRIPTION
While evaluating how the LoadInFlash func works, I realized we haven't set this function to work from RAM. While I haven't seen problems related to this, and presumably this works well right now because it may be in XIP cache, this should be explicitly in RAM. This adds 688 bytes of RAM usage. 