### PR TITLE
Fix-ui-after-sample-import

### DIFF
--- a/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
@@ -14,6 +14,7 @@ unsigned int picoTrackerEventManager::keyRepeat_ = 25;
 unsigned int picoTrackerEventManager::keyDelay_ = 500;
 unsigned int picoTrackerEventManager::keyKill_ = 5;
 repeating_timer_t picoTrackerEventManager::timer_ = repeating_timer_t();
+bool picoTrackerEventManager::isClockRunning_ = true;
 
 uint16_t gTime_ = 0;
 
@@ -22,7 +23,7 @@ picoTrackerEventQueue *queue;
 bool timerHandler(repeating_timer_t *rt) {
   queue = picoTrackerEventQueue::GetInstance();
   gTime_++;
-  if (gTime_ % 1000 == 0) {
+  if (gTime_ % 1000 == 0 && picoTrackerEventManager::ClockRunning()) {
     if (!queue->full()) {
       queue->push(picoTrackerEvent(PICO_CLOCK));
     }

--- a/sources/Adapters/picoTracker/gui/picoTrackerEventManager.h
+++ b/sources/Adapters/picoTracker/gui/picoTrackerEventManager.h
@@ -17,6 +17,9 @@ public:
   virtual int MainLoop();
   virtual void PostQuitMessage();
   virtual int GetKeyCode(const char *name);
+  virtual void PauseClock() { isClockRunning_ = false; }
+  virtual void RunClock() { isClockRunning_ = true; }
+  static bool ClockRunning() { return isClockRunning_; }
 
 protected:
   static void ProcessInputEvent();
@@ -33,5 +36,6 @@ private:
   static bool isRepeating_;
   static unsigned long time_;
   KeyboardControllerSource *keyboardCS_;
+  static bool isClockRunning_;
 };
 #endif

--- a/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/PagedImportSampleDialog.cpp
@@ -3,6 +3,7 @@
 #include "Application/Instruments/SampleInstrument.h"
 #include "Application/Instruments/SamplePool.h"
 #include "Externals/etl/include/etl/string.h"
+#include "UIFramework/Interfaces/I_GUIWindowFactory.h"
 
 #ifdef PICOBUILD
 #include "pico/multicore.h"
@@ -171,7 +172,12 @@ void PagedImportSampleDialog::import(Path &element) {
   // https://www.raspberrypi.com/documentation/pico-sdk/high_level.html#multicore_lockout
   multicore_lockout_start_blocking();
 #endif
+
+  auto eventManager = I_GUIWindowFactory::GetInstance()->GetEventManager();
+  eventManager->PauseClock();
   int sampleID = pool->ImportSample(element);
+  eventManager->RunClock();
+
 #ifdef PICOBUILD
   multicore_lockout_end_blocking();
 #endif

--- a/sources/UIFramework/SimpleBaseClasses/EventManager.h
+++ b/sources/UIFramework/SimpleBaseClasses/EventManager.h
@@ -36,7 +36,8 @@ public:
   virtual int GetKeyCode(const char *name) = 0;
   void MapAppButton(const char *mapping, AppButton button);
   void InstallMappings();
-
+  virtual void PauseClock() = 0;
+  virtual void RunClock()  = 0;
 protected:
   void mapConfigKey(AppButton button, const char *keyName);
 

--- a/sources/UIFramework/SimpleBaseClasses/EventManager.h
+++ b/sources/UIFramework/SimpleBaseClasses/EventManager.h
@@ -37,7 +37,8 @@ public:
   void MapAppButton(const char *mapping, AppButton button);
   void InstallMappings();
   virtual void PauseClock() = 0;
-  virtual void RunClock()  = 0;
+  virtual void RunClock() = 0;
+
 protected:
   void mapConfigKey(AppButton button, const char *keyName);
 


### PR DESCRIPTION
This adds the ability to pause and then restart the 1HZ UI tick clock, which needs to be done during sample import so as not to fill the event queue with clock events, as the event queue is not serviced during import as the CPU is tied up.

Fixes: #144