### PR TITLE
Better event queue

### DIFF
--- a/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
@@ -23,9 +23,7 @@ bool timerHandler(repeating_timer_t *rt) {
   queue = picoTrackerEventQueue::GetInstance();
   gTime_++;
   if (gTime_ % 1000 == 0) {
-    if (!queue->full()) {
-      queue->push(picoTrackerEvent(PICO_CLOCK));
-    }
+    queue->push(picoTrackerEvent(PICO_CLOCK));
   }
   return true;
 }
@@ -54,12 +52,11 @@ int picoTrackerEventManager::MainLoop() {
     loops++;
     ProcessInputEvent();
     if (!queue->empty()) {
-      picoTrackerEvent event(PICO_NONE);
+      picoTrackerEvent event(picoTrackerEventType::LAST);
       queue->pop_into(event);
       events++;
       redrawing_ = true;
       picoTrackerGUIWindowImp::ProcessEvent(event);
-      queue->clear(); // Avoid duplicates redraw
       redrawing_ = false;
     }
 #ifdef PICOSTATS

--- a/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
@@ -110,14 +110,7 @@ void picoTrackerGUIWindowImp::Unlock(){};
 void picoTrackerGUIWindowImp::Flush() { mode0_draw_changed(); };
 
 void picoTrackerGUIWindowImp::Invalidate() {
-  // TODO: better logic here if we want to use more event types, we don't care
-  // to drop since we only have one event type
-  if (!picoTrackerEventQueue::GetInstance()->full()) {
-    picoTrackerEventQueue::GetInstance()->push(picoTrackerEvent(PICO_REDRAW));
-
-  } else {
-    Trace::Log("EVENT QUEUE", "full");
-  }
+  picoTrackerEventQueue::GetInstance()->push(picoTrackerEvent(PICO_REDRAW));
 };
 
 void picoTrackerGUIWindowImp::PushEvent(GUIEvent &event) {
@@ -139,7 +132,7 @@ void picoTrackerGUIWindowImp::ProcessEvent(picoTrackerEvent &event) {
   case PICO_CLOCK:
     instance_->_window->ClockTick();
     break;
-  case PICO_NONE:
+  case LAST:
     break;
   }
 }

--- a/sources/Adapters/picoTracker/system/picoTrackerEventQueue.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerEventQueue.cpp
@@ -2,15 +2,14 @@
 
 picoTrackerEventQueue::picoTrackerEventQueue(){};
 void picoTrackerEventQueue::push(picoTrackerEvent event) {
-  if (!queued_.contains(event.type_)) {
-    queue_.push(event);
-    queued_.insert(event.type_);
+  if (std::find(queue_.begin(), queue_.end(), event) == queue_.end()) {
+    queue_.push_back(event);
   }
 };
 
 void picoTrackerEventQueue::pop_into(picoTrackerEvent &event) {
-  queued_.erase(event.type_);
-  queue_.pop_into(event);
+  event.type_ = queue_.front().type_;
+  queue_.pop_front();
 };
 
 bool picoTrackerEventQueue::empty() { return queue_.empty(); }

--- a/sources/Adapters/picoTracker/system/picoTrackerEventQueue.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerEventQueue.cpp
@@ -1,3 +1,16 @@
 #include "picoTrackerEventQueue.h"
 
 picoTrackerEventQueue::picoTrackerEventQueue(){};
+void picoTrackerEventQueue::push(picoTrackerEvent event) {
+  if (!queued_.contains(event.type_)) {
+    queue_.push(event);
+    queued_.insert(event.type_);
+  }
+};
+
+void picoTrackerEventQueue::pop_into(picoTrackerEvent &event) {
+  queued_.erase(event.type_);
+  queue_.pop_into(event);
+};
+
+bool picoTrackerEventQueue::empty() { return queue_.empty(); }

--- a/sources/Adapters/picoTracker/system/picoTrackerEventQueue.h
+++ b/sources/Adapters/picoTracker/system/picoTrackerEventQueue.h
@@ -1,19 +1,11 @@
 #ifndef _PICOTRACKEREVENTQUEUE_H_
 #define _PICOTRACKEREVENTQUEUE_H_
 
-#include "Externals/etl/include/etl/stack.h"
+#include "Externals/etl/include/etl/queue.h"
+#include "Externals/etl/include/etl/set.h"
 #include "Foundation/T_Singleton.h"
-#include "Foundation/T_Stack.h"
 
-enum picoTrackerEventType {
-  PICO_NONE,
-  //  PICO_KEYDOWN,
-  //  PICO_KEYUP,
-  //  PICO_QUIT,
-  PICO_REDRAW,
-  PICO_CLOCK,
-  //  PICO_USEREVENT
-};
+enum picoTrackerEventType { PICO_REDRAW, PICO_CLOCK, LAST };
 
 class picoTrackerEvent {
 public:
@@ -22,10 +14,18 @@ public:
   picoTrackerEventType type_;
 };
 
-class picoTrackerEventQueue : public T_Singleton<picoTrackerEventQueue>,
-                              public etl::stack<picoTrackerEvent, 5> {
+class picoTrackerEventQueue : public T_Singleton<picoTrackerEventQueue> {
 public:
   picoTrackerEventQueue();
+  void push(picoTrackerEvent event);
+  void pop_into(picoTrackerEvent &event);
+  bool empty();
+
+private:
+  etl::queue<picoTrackerEvent, picoTrackerEventType::LAST,
+             etl::memory_model::MEMORY_MODEL_SMALL>
+      queue_;
+  etl::set<picoTrackerEventType, picoTrackerEventType::LAST> queued_;
 };
 
 #endif

--- a/sources/Adapters/picoTracker/system/picoTrackerEventQueue.h
+++ b/sources/Adapters/picoTracker/system/picoTrackerEventQueue.h
@@ -1,8 +1,7 @@
 #ifndef _PICOTRACKEREVENTQUEUE_H_
 #define _PICOTRACKEREVENTQUEUE_H_
 
-#include "Externals/etl/include/etl/queue.h"
-#include "Externals/etl/include/etl/set.h"
+#include "Externals/etl/include/etl/deque.h"
 #include "Foundation/T_Singleton.h"
 
 enum picoTrackerEventType { PICO_REDRAW, PICO_CLOCK, LAST };
@@ -10,8 +9,12 @@ enum picoTrackerEventType { PICO_REDRAW, PICO_CLOCK, LAST };
 class picoTrackerEvent {
 public:
   picoTrackerEvent(picoTrackerEventType type) : type_(type) {}
-
   picoTrackerEventType type_;
+};
+
+inline bool operator==(const picoTrackerEvent &lhs,
+                       const picoTrackerEvent &rhs) {
+  return lhs.type_ == rhs.type_;
 };
 
 class picoTrackerEventQueue : public T_Singleton<picoTrackerEventQueue> {
@@ -22,10 +25,7 @@ public:
   bool empty();
 
 private:
-  etl::queue<picoTrackerEvent, picoTrackerEventType::LAST,
-             etl::memory_model::MEMORY_MODEL_SMALL>
-      queue_;
-  etl::set<picoTrackerEventType, picoTrackerEventType::LAST> queued_;
+  etl::deque<picoTrackerEvent, picoTrackerEventType::LAST> queue_;
 };
 
 #endif


### PR DESCRIPTION
There are moments where the event queue can be starved with the same event and cause problems. This changes the implementation to only add events that are not currently in the queue.