### PR TITLE
static RenderParams. Saves 43Kb memory

### DIFF
--- a/sources/Application/Instruments/SampleInstrument.cpp
+++ b/sources/Application/Instruments/SampleInstrument.cpp
@@ -20,6 +20,8 @@
 
 bool SampleInstrument::useDirtyDownsampling_ = false;
 
+renderParams SampleInstrument::renderParams_[SONG_CHANNEL_COUNT];
+
 #define SHOULD_KILL_CLICKS false
 
 signed char SampleInstrument::lastMidiNote_[SONG_CHANNEL_COUNT];

--- a/sources/Application/Instruments/SampleInstrument.h
+++ b/sources/Application/Instruments/SampleInstrument.h
@@ -92,7 +92,7 @@ protected:
 
 private:
   SoundSource *source_;
-  struct renderParams renderParams_[SONG_CHANNEL_COUNT];
+  static struct renderParams renderParams_[SONG_CHANNEL_COUNT];
   bool running_;
   bool dirty_;
   TableSaveState tableState_;


### PR DESCRIPTION
@maks I had a sense that this could be done, but it was suspiciously easy. Please check this in detail in case I missed anything, but seems to work fine and makes sense because this just stores the data for each track of the last instrument using it, whereas before each instrument was savings it's own data for each track where it might have played, even if that state is not really needed once another instrument triggered on the same track.