### PR TITLE
add dev container config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "Debian with RP2040 dev toolchain",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "ghcr.io/maks/rp2040-devcontainer:latest"
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
This makes it easy for someone who is already using devcontainers or who installs a tool that makes them easy to use (eg. VSCode) to get the required tools using the prebuilt docker container (https://github.com/maks/rp2040-devcontainer) I have made, but at the cost of approx 3.8 GB container image. This is especially true for anyone not already using a Ubuntu or Debian based Linux OS, where the instructions from the Pico SDK docs wouldn't work.

For now its only the gcc arm compiler, cmake and other prerequites specified by the Pico C SDK docs but I plan to also add OpenOCD to the image as well.
Also I plan to look at making the image *much* smaller in the future by switching to slimmer version of a base OS image.