### PR TITLE
Enable the PROJECT_NUMBER, PROJECT_RELEASE and BUILD_COUNT to be overridden when running cmake

### DIFF
--- a/sources/Application/Model/BuildNumber.h
+++ b/sources/Application/Model/BuildNumber.h
@@ -1,1 +1,3 @@
+#ifndef BUILD_COUNT
 #define BUILD_COUNT "003"
+#endif

--- a/sources/Application/Model/Project.h
+++ b/sources/Application/Model/Project.h
@@ -16,8 +16,12 @@
 #define VAR_TRANSPOSE MAKE_FOURCC('T', 'R', 'S', 'P')
 #define VAR_SCALE MAKE_FOURCC('S', 'C', 'A', 'L')
 
+#ifndef PROJECT_NUMBER
 #define PROJECT_NUMBER "1.0"
+#endif
+#ifndef PROJECT_RELEASE
 #define PROJECT_RELEASE "r"
+#endif
 // BUILD_COUNT define comes from BuildNumber.h
 
 #define MAX_TAP 3

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -11,6 +11,24 @@ if (PICO_SDK_VERSION_STRING VERSION_LESS "1.3.0")
     message(FATAL_ERROR "Raspberry Pi Pico SDK version 1.3.0 (or later) required. Your version is ${PICO_SDK_VERSION_STRING}")
 endif()
 
+# Set default project number if not provided
+if(NOT DEFINED PROJECT_NUMBER)
+    set(PROJECT_NUMBER "1.0")
+endif()
+add_definitions(-DPROJECT_NUMBER="${PROJECT_NUMBER}")
+
+# Set default project release if not provided
+if(NOT DEFINED PROJECT_RELEASE)
+  set(PROJECT_RELEASE "r")
+endif()
+add_definitions(-DPROJECT_RELEASE="${PROJECT_RELEASE}")
+
+# Set default build count if not provided
+if(NOT DEFINED BUILD_COUNT)
+  set(BUILD_COUNT "003")
+endif()
+add_definitions(-DBUILD_COUNT="${BUILD_COUNT}")
+
 # Make this a picoTracker build within the project
 add_definitions(-DPICOBUILD)
 


### PR DESCRIPTION
Updates the defines in the project to be surrounded by #ifndef statements so existing functionality should not be changed.

Updates the CMakeLists.txt file to accept the following flags from the command line when doing a cmake on the project...

-DPROJECT_NUMBER
-DPROJECT_RELEASE
-DBUILD_COUNT

Also with the appropriate defaults that already exist in the existing files.

I'm not sure how these values are updated (are they updated manually or during a pipline build?) if so it would probably be best to remove the defaults from the source code an rely on the config in the CMakeList.txt file. (If this pull request is accepted in the first place :)